### PR TITLE
CI: Don't cancel other jobs if one fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        # Tested versions based on dates in https://devguide.python.org/devcycle/#end-of-life-branches, 
+        # Tested versions based on dates in https://devguide.python.org/devcycle/#end-of-life-branches,
         python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
If one job fails for some reason, don't automatically cancel the others.

Helps for situations like https://github.com/actions/setup-python/issues/317, where a failure only occurs on a single Python version.

Demo with the pins undone:

![image](https://user-images.githubusercontent.com/1324225/149512278-d8cb3206-06b2-466e-9f8f-3f92dc2fe0ef.png)

https://github.com/hugovk/octodns-route53/actions/runs/1697548254