### PR TITLE
Have setup.py require boto3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name='octodns-route53',
     packages=find_packages(),
     python_requires='>=3.6',
-    install_requires=('octodns>=0.9.14', 'boto>=1.20.26'),
+    install_requires=('octodns>=0.9.14', 'boto3>=1.20.26'),
     url='https://github.com/octodns/octodns-route53',
     version=version(),
     tests_require=[


### PR DESCRIPTION
This pull request proposes changing **boto** to **boto3** in **setup.py**.

When I did `pip install -r` this requirements.txt:

```text
octodns==0.9.14
octodns_route53==0.0.2
```

**boto3** was unavailable and `octodns-sync` failed:

```text
ModuleNotFoundError: No module named 'boto3'
```

I think that's because **setup.py** currently requires **boto** rather than **boto3**, tho I'm not clear how to test that. Please let me know if y'all prefer a different approach :bow: