### PR TITLE
Version 0.0.3 bump and CHANGELOG update #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.3 - 2022-01-11 - What we really need
+
+* Fix boto -> boto3 type-o/problem with setup.py
+* Switch to pytest since nose is long :skull:ed
+
 ## v0.0.2 - 2022-01-11 - setup.py fixes
 
 * setup.py now uses find_packages so that processors are now found/included

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.3 - 2022-01-11 - What we really need
+## v0.0.3 - 2022-01-23 - What we really need
 
 * Fix boto -> boto3 type-o/problem with setup.py
 * Switch to pytest since nose is long :skull:ed

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -17,7 +17,7 @@ from octodns.record.geo import GeoCodes
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 octal_re = re.compile(r'\\(\d\d\d)')
 


### PR DESCRIPTION
## v0.0.3 - 2022-01-23 - What we really need

* Fix boto -> boto3 type-o/problem with setup.py
* Switch to pytest since nose is long :skull:ed