### PR TITLE
Root NS record support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.5 - 2022-??-?? - Support the root
+
+* Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
+  octodns>=0.9.16.
+
 ## v0.0.4 - 2022-02-02 - pycountry-convert install_requires
 
 * install_requires includes pycountry-convert as it's a runtime requirement

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ zones:
 
 A, AAAA, CAA, CNAME, MX, NAPTR, NS, PTR, SPF, SRV, TXT
 
+#### Root NS Records
+
+Route53Provider supports full root NS record management.
+
 #### Dynamic
 
 Route53Provider supports dynamic records, CNAME health checks don't support a Host header.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ idna==3.3
 iniconfig==1.1.1
 jmespath==0.10.0
 natsort==8.1.0
-octodns==0.9.14
 packaging==21.3
 pluggy==1.0.0
 pprintpp==0.4.0
@@ -30,3 +29,5 @@ six==1.16.0
 toml==0.10.2
 tomli==2.0.0
 urllib3==1.26.8
+
+-e git+https://git@github.com/github/octodns.git@root-ns-support#egg=octodns

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ idna==3.3
 iniconfig==1.1.1
 jmespath==0.10.0
 natsort==8.1.0
+octodns==0.9.16
 packaging==21.3
 pluggy==1.0.0
 pprintpp==0.4.0
@@ -29,5 +30,3 @@ six==1.16.0
 toml==0.10.2
 tomli==2.0.0
 urllib3==1.26.8
-
--e git+https://git@github.com/github/octodns.git@root-ns-support#egg=octodns

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     },
     install_requires=(
         'boto3>=1.20.26',
-        'octodns>=0.9.14',
+        'octodns>=0.9.16',
         'pycountry-convert>=0.7.2',
     ),
     license='MIT',


### PR DESCRIPTION

Main hiccup here is that the Create NS on a new zone has to be converted into an Update. Once coded up that goes fairly smoothly and otherwise things just work. Route53 will let you completely manage the root NS records.

/cc https://github.com/octodns/octodns/pull/876 which this requires