### PR TITLE
Implementation of the Route53 specific symlink style ALIAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
   octodns>=0.9.16.
+* Add support for Route53Provider/ALIAS provider-specific type, see README for
+  more information.
 
 ## v0.0.4 - 2022-02-02 - pycountry-convert install_requires
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ Route53Provider supports full root NS record management.
 
 Route53Provider supports dynamic records, CNAME health checks don't support a Host header.
 
+#### Provider Specific Types
+
+`Route53Provider/ALIAS` adds support for the Route53 specific symlink style alias records.
+
+```yaml
+alias:
+    type: Route53Provider/ALIAS
+    values:
+    # ALIAS for the zone APEX A record
+    - type: A
+    # ALIAS for www.whatever.com. AAAA
+    - evaluate-target-health: false
+      name: www
+      type: AAAA
+```
+
 #### Health Check Options
 
 See https://github.com/octodns/octodns/blob/master/docs/dynamic_records.md#health-checks for information on health checking for dynamic records. Route53Provider supports the following options:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Route53Provider supports dynamic records, CNAME health checks don't support a Ho
 `Route53Provider/ALIAS` adds support for the Route53 specific symlink style alias records.
 
 ```yaml
+# "symlink" to another record in the same zone
 alias:
     type: Route53Provider/ALIAS
     values:
@@ -92,8 +93,19 @@ alias:
     - type: A
     # ALIAS for www.whatever.com. AAAA
     - evaluate-target-health: false
+      # same-zone aliases omit the zone name
       name: www
       type: AAAA
+# "symlink" to a AWS service
+alb:
+    type: Route53Provider/ALIAS
+    value:
+        # default for evaluate-target-health is False
+        evaluate-target-health: true
+        # hosted-zone-id should only be used when pointing to service endpoints
+        hosted-zone-id: Z42SXDOTRQ7X7K
+        name: dualstack.octodns-testing-1165866977.us-east-1.elb.amazonaws.com.
+        type: A
 ```
 
 #### Health Check Options

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -42,6 +42,28 @@ def _healthcheck_ref_prefix(version, record_type, record_fqdn):
     return ref
 
 
+# Since Route53's alias type reuses the same keys for different types of
+# records with nothing to definitively indicate whether it's a service or
+# same-zone symlink we need to guess which based on the fqdn. We can't do an
+# `endswith` due to cases where there are country specific endings on the fqdn,
+# e.g. `.cn`. No clue if this will work for gov-cloud etc. If you encounter a
+# case where a service isn't correctly being detected please open a PR adding
+# it's fqdn bit to the list here or an issue if that doesn't make sense.
+# https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-alias-common.html#rrsets-values-alias-common-target
+_service_fqdns = (
+    'amazonaws.com.',
+    'cloudfront.net.',
+    'elasticbeanstalk.com.',
+)
+
+
+def _service_alias(name):
+    for service_fqdn in _service_fqdns:
+        if service_fqdn in name:
+            return True
+    return False
+
+
 class _Route53Record(EqualityTupleMixin):
 
     @classmethod
@@ -277,7 +299,7 @@ class _Route53Alias(_Route53Record):
         self.fqdn = record.fqdn
         name = value.name
         if name:
-            if 'amazonaws.com.' in name:
+            if _service_alias(name):
                 # It's a service symlink, just use it as is
                 self.target_name = name
             else:
@@ -1045,7 +1067,7 @@ class Route53Provider(BaseProvider):
         for rrset in rrsets:
             target = rrset['AliasTarget']
             name = target['DNSName']
-            if 'amazonaws.com.' in name:
+            if _service_alias(name):
                 # We only set hosted_zone_id when it's a "service" alias, when
                 # it's a pointer to the current zone it'll be None
                 hosted_zone_id = target['HostedZoneId']

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -18,6 +18,8 @@ from octodns.record.geo import GeoCodes
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
+from .record import Route53AliasRecord
+
 __VERSION__ = '0.0.4'
 
 octal_re = re.compile(r'\\(\d\d\d)')
@@ -41,6 +43,17 @@ def _healthcheck_ref_prefix(version, record_type, record_fqdn):
 
 
 class _Route53Record(EqualityTupleMixin):
+
+    @classmethod
+    def _new_route53_alias(cls, provider, record, hosted_zone_id, creating):
+        # HostedZoneId wants just the last bit, but the place we're getting
+        # this from looks like /hostedzone/Z424CArX3BB224
+        hosted_zone_id = hosted_zone_id.split('/', 2)[-1]
+
+        return set([
+            _Route53Alias(provider, hosted_zone_id, record, value, creating)
+            for value in record.values
+        ])
 
     @classmethod
     def _new_dynamic(cls, provider, record, hosted_zone_id, creating):
@@ -138,6 +151,9 @@ class _Route53Record(EqualityTupleMixin):
             return ret
         elif getattr(record, 'geo', False):
             return cls._new_geo(provider, record, creating)
+        elif record._type == Route53AliasRecord._type:
+            return cls._new_route53_alias(provider, record, hosted_zone_id,
+                                          creating)
 
         # Its a simple record that translates into a single RRSet
         return set((_Route53Record(provider, record, creating),))
@@ -146,11 +162,20 @@ class _Route53Record(EqualityTupleMixin):
         self.fqdn = fqdn_override or record.fqdn
         self._type = record._type
         self.ttl = record.ttl
+        self.record = record
 
-        values_for = getattr(self, f'_values_for_{self._type}')
-        self.values = values_for(record)
+        self._values = None
+
+    @property
+    def values(self):
+        if self._values is None:
+            _type = self._type.replace('/', '_')
+            values_for = getattr(self, f'_values_for_{_type}')
+            self._values = values_for(self.record)
+        return self._values
 
     def mod(self, action, existing_rrsets):
+
         return {
             'Action': action,
             'ResourceRecordSet': {
@@ -239,6 +264,37 @@ class _Route53Record(EqualityTupleMixin):
 
     def _values_for_SRV(self, record):
         return [self._value_for_SRV(v, record) for v in record.values]
+
+
+class _Route53Alias(_Route53Record):
+
+    def __init__(self, provider, hosted_zone_id, record, value, creating):
+        super().__init__(provider, record, creating)
+        self.hosted_zone_id = hosted_zone_id
+        self.fqdn = record.fqdn
+        self.target_name = value.name
+        self.target_type = value._type
+
+    def mod(self, action, existing_rrsets):
+        return {
+            'Action': action,
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': self.target_name,
+                    'EvaluateTargetHealth': False,
+                    'HostedZoneId': self.hosted_zone_id,
+                },
+                'Name': self.fqdn,
+                'Type': self.target_type,
+            }
+        }
+
+    def __hash__(self):
+        return f'{self.fqdn}:{self.target_type}:{self.target_name}'.__hash__()
+
+    def __repr__(self):
+        return f'_Route53Alias<{self.fqdn} {self.target_type} ' \
+            f'{self.target_name}>'
 
 
 class _Route53DynamicPool(_Route53Record):
@@ -621,7 +677,7 @@ class Route53Provider(BaseProvider):
     SUPPORTS_POOL_VALUE_STATUS = True
     SUPPORTS_ROOT_NS = True
     SUPPORTS = set(('A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NAPTR', 'NS', 'PTR',
-                    'SPF', 'SRV', 'TXT'))
+                    'SPF', 'SRV', 'TXT', Route53AliasRecord._type))
 
     # This should be bumped when there are underlying changes made to the
     # health check config.
@@ -968,6 +1024,22 @@ class Route53Provider(BaseProvider):
 
         return data
 
+    def _data_for_route53_alias(self, rrsets):
+        values = []
+        for rrset in rrsets:
+            target = rrset['AliasTarget']
+            # TODO: this only supports the symlink style alias pointing to
+            # other records in the same zone. Need more data/examples to
+            # support things like ELB targets and all the other options
+            values.append({
+                'name': target['DNSName'],
+                'type': rrset['Type'],
+            })
+        return {
+            'type': Route53AliasRecord._type,
+            'values': values,
+        }
+
     def _process_desired_zone(self, desired):
         for record in desired.records:
             if getattr(record, 'dynamic', False):
@@ -1016,6 +1088,7 @@ class Route53Provider(BaseProvider):
             exists = True
             records = defaultdict(lambda: defaultdict(list))
             dynamic = defaultdict(lambda: defaultdict(list))
+            aliases = defaultdict(list)
 
             for rrset in self._load_records(zone_id):
                 record_name = zone.hostname_from_fqdn(rrset['Name'])
@@ -1037,10 +1110,7 @@ class Route53Provider(BaseProvider):
                         # Part of a dynamic record
                         dynamic[record_name][record_type].append(rrset)
                     else:
-                        # Alias records are Route53 specific and are not
-                        # portable, so we need to skip them
-                        self.log.warning("%s is an Alias record. Skipping..."
-                                         % rrset['Name'])
+                        aliases[record_name].append(rrset)
                     continue
                 # A basic record (potentially including geo)
                 data = getattr(self, f'_data_for_{record_type}')(rrset)
@@ -1073,6 +1143,19 @@ class Route53Provider(BaseProvider):
                     record = Record.new(zone, name, data, source=self,
                                         lenient=lenient)
                     zone.add_record(record, lenient=lenient)
+
+            # Route53 Aliases don't have TTLs so we're setting a dummy value
+            # here and will ignore any ttl-only changes down below in
+            # _include_change in order to avoid persistent changes that can't
+            # be synced.  It's a bit ugly, but there's nothing we can do since
+            # octoDNS requires a TTL and Route53 doesn't have one on their
+            # ALIAS records.
+            for name, rrsets in aliases.items():
+                data = self._data_for_route53_alias(rrsets)
+                data['ttl'] = 942942942
+                record = Record.new(zone, name, data, source=self,
+                                    lenient=lenient)
+                zone.add_record(record, lenient=lenient)
 
         self.log.info('populate:   found %s records, exists=%s',
                       len(zone.records) - before, exists)
@@ -1489,6 +1572,11 @@ class Route53Provider(BaseProvider):
                     extras.append(Update(record, record))
 
         return extras
+
+    def _include_change(self, change):
+        return not (isinstance(change, Update) and
+                    change.new._type == Route53AliasRecord._type and
+                    change.new.values == change.existing.values)
 
     def _apply(self, plan):
         desired = plan.desired

--- a/octodns_route53/record.py
+++ b/octodns_route53/record.py
@@ -10,8 +10,6 @@ class _Route53AliasValue(EqualityTupleMixin):
             data = (data,)
         reasons = []
         for value in data:
-            if 'name' not in value:
-                reasons.append('missing name')
             if 'type' not in value:
                 reasons.append('missing type')
 
@@ -22,8 +20,10 @@ class _Route53AliasValue(EqualityTupleMixin):
         return [_Route53AliasValue(v) for v in values]
 
     def __init__(self, value):
-        self.name = value['name']
+        self.name = value.get('name', '')
         self._type = value['type']
+        self.evaluate_target_health = value.get('evaluate-target-health',
+                                                False)
 
     @property
     def data(self):

--- a/octodns_route53/record.py
+++ b/octodns_route53/record.py
@@ -1,0 +1,50 @@
+from octodns.record import Record, ValuesMixin
+from octodns.equality import EqualityTupleMixin
+
+
+class _Route53AliasValue(EqualityTupleMixin):
+
+    @classmethod
+    def validate(cls, data, _type):
+        if not isinstance(data, (list, tuple)):
+            data = (data,)
+        reasons = []
+        for value in data:
+            if 'name' not in value:
+                reasons.append('missing name')
+            if 'type' not in value:
+                reasons.append('missing type')
+
+        return reasons
+
+    @classmethod
+    def process(cls, values):
+        return [_Route53AliasValue(v) for v in values]
+
+    def __init__(self, value):
+        self.name = value['name']
+        self._type = value['type']
+
+    @property
+    def data(self):
+        return {
+            'name': self.name,
+            'type': self._type,
+        }
+
+    def __hash__(self):
+        return hash((self._type, self.name))
+
+    def _equality_tuple(self):
+        return (self._type, self.name)
+
+    def __repr__(self):
+        return f'{self.name} {self._type}'
+
+
+class Route53AliasRecord(ValuesMixin, Record):
+    _type = 'Route53Provider/ALIAS'
+    _value_type = _Route53AliasValue
+
+
+Record.register_type(Route53AliasRecord)

--- a/octodns_route53/record.py
+++ b/octodns_route53/record.py
@@ -12,6 +12,12 @@ class _Route53AliasValue(EqualityTupleMixin):
         for value in data:
             if 'type' not in value:
                 reasons.append('missing type')
+            if 'amazonaws.com.' in (value.get('name') or ''):
+                if not value.get('hosted-zone-id'):
+                    reasons.append('service alias without hosted-zone-id')
+            else:
+                if value.get('hosted-zone-id'):
+                    reasons.append('hosted-zone-id on a non-service value')
 
         return reasons
 
@@ -20,26 +26,29 @@ class _Route53AliasValue(EqualityTupleMixin):
         return [_Route53AliasValue(v) for v in values]
 
     def __init__(self, value):
-        self.name = value.get('name', '')
+        self.name = value.get('name') or ''
         self._type = value['type']
         self.evaluate_target_health = value.get('evaluate-target-health',
                                                 False)
+        self.hosted_zone_id = value.get('hosted-zone-id')
 
     @property
     def data(self):
         return {
+            'hosted-zone-id': self.hosted_zone_id,
+            'evaluate-target-health': self.evaluate_target_health,
             'name': self.name,
             'type': self._type,
         }
 
     def __hash__(self):
-        return hash((self._type, self.name))
+        return hash((self._type, self.name, self.hosted_zone_id))
 
     def _equality_tuple(self):
-        return (self._type, self.name)
+        return (self._type, self.name, self.hosted_zone_id)
 
     def __repr__(self):
-        return f'{self.name} {self._type}'
+        return f'"{self.name}" {self._type} {self.hosted_zone_id or ""}'
 
 
 class Route53AliasRecord(ValuesMixin, Record):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ fqdn==1.5.1
 iniconfig==1.1.1
 jmespath==0.10.0
 natsort==8.1.0
+octodns==0.9.17
 packaging==21.3
 pluggy==1.0.0
 pprintpp==0.4.0
@@ -24,5 +25,3 @@ s3transfer==0.5.2
 six==1.16.0
 tomli==2.0.1
 urllib3==1.26.8
-
--e git+https://git@github.com/github/octodns.git@master#egg=octodns

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ six==1.16.0
 tomli==2.0.1
 urllib3==1.26.8
 
--e git+https://git@github.com/github/octodns.git@record-type-registration#egg=octodns
+-e git+https://git@github.com/github/octodns.git@master#egg=octodns

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ fqdn==1.5.1
 iniconfig==1.1.1
 jmespath==0.10.0
 natsort==8.1.0
-octodns==0.9.16
 packaging==21.3
 pluggy==1.0.0
 pprintpp==0.4.0
@@ -25,3 +24,5 @@ s3transfer==0.5.2
 six==1.16.0
 tomli==2.0.1
 urllib3==1.26.8
+
+-e git+https://git@github.com/github/octodns.git@record-type-registration#egg=octodns

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     },
     install_requires=(
         'boto3>=1.20.26',
-        'octodns>=0.9.16',
+        'octodns>=0.9.17',
         'pycountry-convert>=0.7.2',
     ),
     license='MIT',

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -3765,6 +3765,20 @@ class TestRoute53AliasRecord(TestCase):
             'type': 'A',
         }, Route53AliasRecord._type))
 
+        # valid service (cloudfront)
+        self.assertEqual([], _Route53AliasValue.validate({
+            'name': 'foo.bar.cloudfront.net.',
+            'hosted-zone-id': 'good',
+            'type': 'A',
+        }, Route53AliasRecord._type))
+
+        # valid service (elasticbeanstalk)
+        self.assertEqual([], _Route53AliasValue.validate({
+            'name': 'foo.bar.elasticbeanstalk.com.',
+            'hosted-zone-id': 'good',
+            'type': 'A',
+        }, Route53AliasRecord._type))
+
     def test_route53_record_conversion(self):
         alias = Route53AliasRecord(zone, 'alias', {
             'values': [{

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -347,10 +347,13 @@ class TestRoute53Provider(TestCase):
              'value': 'ca.unit.tests'
          }}),
         ('alias',
-         {'ttl': 942942942, 'type': 'Route53Provider/ALIAS', 'value': {
-             'name': 'unit.tests.',
+         {'ttl': 942942942, 'type': 'Route53Provider/ALIAS', 'values': [{
+             'name': '',
              'type': 'A',
-         }}),
+         }, {
+             'name': 'naptr',
+             'type': 'NAPTR',
+         }]}),
     ):
         record = Record.new(expected, name, data)
         expected.add_record(record)
@@ -815,7 +818,14 @@ class TestRoute53Provider(TestCase):
                 },
                 'Type': 'A',
                 'Name': 'alias.unit.tests.',
-                'TTL': 70,
+            }, {
+                'AliasTarget': {
+                    'HostedZoneId': 'Z119WBBTVP5WFX',
+                    'EvaluateTargetHealth': False,
+                    'DNSName': 'naptr.unit.tests.'
+                },
+                'Type': 'NAPTR',
+                'Name': 'alias.unit.tests.',
             }],
             'IsTruncated': False,
             'MaxItems': '100',
@@ -3676,10 +3686,10 @@ class TestRoute53AliasRecord(TestCase):
     def test_basics(self):
         alias = Route53AliasRecord(zone, 'alias', {
             'values': [{
-                'name': f'something.{zone.name}',
+                'name': 'something',
                 'type': 'A',
             }, {
-                'name': f'another.{zone.name}',
+                'name': '',
                 'type': 'AAAA',
             }],
             'ttl': 42,
@@ -3689,7 +3699,7 @@ class TestRoute53AliasRecord(TestCase):
         v1 = alias.values[1]
 
         self.assertEqual({
-            'name': 'something.unit.tests.',
+            'name': 'something',
             'type': 'A'
         }, v0.data)
 
@@ -3702,7 +3712,6 @@ class TestRoute53AliasRecord(TestCase):
         v0.__repr__()
 
         self.assertEqual([
-            'missing name',
             'missing type'
         ], _Route53AliasValue.validate({}, Route53AliasRecord._type))
 
@@ -3714,10 +3723,10 @@ class TestRoute53AliasRecord(TestCase):
     def test_route53_record_conversion(self):
         alias = Route53AliasRecord(zone, 'alias', {
             'values': [{
-                'name': f'something.{zone.name}',
+                'name': 'something',
                 'type': 'A',
             }, {
-                'name': f'another.{zone.name}',
+                'name': None,
                 'type': 'AAAA',
             }],
             'ttl': 42,
@@ -3741,7 +3750,7 @@ class TestRoute53AliasRecord(TestCase):
             'Action': 'create',
             'ResourceRecordSet': {
                 'AliasTarget': {
-                    'DNSName': 'another.unit.tests.',
+                    'DNSName': 'unit.tests.',
                     'EvaluateTargetHealth': False,
                     'HostedZoneId': 'z42'
                 },


### PR DESCRIPTION
Now that got around to playing with Record type registration https://github.com/octodns/octodns/pull/889 I was able to poke around at things and implement support for the Route53 ALIAS type, which is not the same as octoDNS's alias. It's specific to Route53 and is essentially a symlink to something. As-is this will only support the "Alias to another record in this hosted zone". 

In order to support more types we need to know what data Route53/boto returns for them, e.g. 

```python
{'AliasTarget': {'DNSName': 'exxampled.com.',
                 'EvaluateTargetHealth': False,
                 'HostedZoneId': 'Z05116462IZ3MBXPYGJTH'},
 'Name': 'alias.exxampled.com.',
 'Type': 'A'}
```

The config for the new provider-specific type looks something like this, the `type` is a convention and not anything magic/dynamic.

```yaml
alias:
  ttl: 33
  type: Route53Provider/ALIAS
  values:
    - name: 
      type: A
    - name: www
      type: AAAA
```

Interestingly the type has no TTL. It's the only record type I've ever run across that doesn't have one. That makes some sense given its nature of being a symlink it just would use the TTL of whatever is being pointed at. That's a complication for octoDNS records which require one. Anyway, they're completely ignored with a provider `_include_change`.

/cc https://github.com/octodns/octodns/pull/889 which this requries since it needs to register a new Record type, CI will fail until that's merged
/cc https://github.com/octodns/octodns-route53/issues/24 which requested ALIAS support