### PR TITLE
Make sure Healthchecks also get deleted when type is CNAME

### DIFF
--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -1287,7 +1287,7 @@ class Route53Provider(BaseProvider):
         return id
 
     def _gc_health_checks(self, record, new):
-        if record._type not in ('A', 'AAAA'):
+        if record._type not in ('A', 'AAAA', 'CNAME'):
             return
         self.log.debug('_gc_health_checks: record=%s', record)
         # Find the health checks we're using for the new route53 records


### PR DESCRIPTION
Was noticing when using CNAME's in dynamic pools it is not deleting the health checks. 