### PR TITLE
Version 0.0.5 bump and CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-## v0.0.5 - 2022-??-?? - Support the root
+## v0.0.5 - 2022-07-14 - Support the root
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
   octodns>=0.9.16.
 * Add support for Route53Provider/ALIAS provider-specific type, see README for
   more information.
+* Health checks ref's use a hash when ref > 64 chars, to support long fqdns.
+* Add support for FailureThreashold in healthchecks
+* Make sure health checks get deleted from CNAME records
 
 ## v0.0.4 - 2022-02-02 - pycountry-convert install_requires
 

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -20,7 +20,7 @@ from octodns.provider.base import BaseProvider
 
 from .record import Route53AliasRecord
 
-__VERSION__ = '0.0.4'
+__VERSION__ = '0.0.5'
 
 octal_re = re.compile(r'\\(\d\d\d)')
 


### PR DESCRIPTION
## v0.0.5 - 2022-07-14 - Support the root

* Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
  octodns>=0.9.16.
* Add support for Route53Provider/ALIAS provider-specific type, see README for
  more information.
* Health checks ref's use a hash when ref > 64 chars, to support long fqdns.
* Add support for FailureThreashold in healthchecks
* Make sure health checks get deleted from CNAME records