### PR TITLE
Don't explode if the requested changeset is empty

### DIFF
--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1851,12 +1851,15 @@ class Route53Provider(_AuthMixin, BaseProvider):
         # Ensure this batch is ordered (deletes before creates etc.)
         batch.sort(key=_mod_keyer)
         uuid = uuid4().hex
-        batch = {'Comment': f'Change: {uuid}', 'Changes': batch}
-        self.log.debug(
-            '_really_apply:   sending change request, comment=%s',
-            batch['Comment'],
-        )
-        resp = self._conn.change_resource_record_sets(
-            HostedZoneId=zone_id, ChangeBatch=batch
-        )
-        self.log.debug('_really_apply:   change info=%s', resp['ChangeInfo'])
+        change_batch = {'Comment': f'Change: {uuid}', 'Changes': batch}
+        if len(batch) == 0:
+            self.log.debug('_really_apply:   no changes to make')
+        else:
+            self.log.debug(
+                '_really_apply:   sending change request, comment=%s',
+                change_batch['Comment'],
+            )
+            resp = self._conn.change_resource_record_sets(
+                HostedZoneId=zone_id, ChangeBatch=change_batch
+            )
+            self.log.debug('_really_apply:   change info=%s', resp['ChangeInfo'])

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1853,13 +1853,12 @@ class Route53Provider(_AuthMixin, BaseProvider):
         uuid = uuid4().hex
         change_batch = {'Comment': f'Change: {uuid}', 'Changes': batch}
         if len(batch) == 0:
-            self.log.debug('_really_apply:   no changes to make')
-        else:
-            self.log.debug(
-                '_really_apply:   sending change request, comment=%s',
-                change_batch['Comment'],
-            )
-            resp = self._conn.change_resource_record_sets(
-                HostedZoneId=zone_id, ChangeBatch=change_batch
-            )
-            self.log.debug('_really_apply:   change info=%s', resp['ChangeInfo'])
+            self.log.error('_really_apply:   no changes to make, called with an empty Plan?')
+        self.log.debug(
+            '_really_apply:   sending change request, comment=%s',
+            change_batch['Comment'],
+        )
+        resp = self._conn.change_resource_record_sets(
+            HostedZoneId=zone_id, ChangeBatch=change_batch
+        )
+        self.log.debug('_really_apply:   change info=%s', resp['ChangeInfo'])


### PR DESCRIPTION
Currently, if a change is planned and executed by the manager but it only contains existing records, then a plan will still be executed and boto will then throw an exception because the requested change is empty.

This PR adds a check to the really_apply function which logs and does nothing if the changeset is empty. It also avoids reusing the name of batch, for clarity when checking if the changeset is empty.

I couldn't quite work out why the apply function was being called in this instance, but I suspect it's because there is one record in the zone (a NS) which gets filtered out by the ownership filter. I figured fixing here should prevent faults occurring if an empty plan is invoked at any point.