### PR TITLE
Add 'Assume Role' capability to the authentication mix-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fixed issue with creating TCP healthchecks for dynamic CNAME records
 * Ec2Source added to support dynamically creating records for Ec2 instances
 * ElbSource added to support dynamically creating records for ELBs
+* role_name added to auth mix-in to support acquiring a specific role from existing credentials 
 
 ## v0.0.5 - 2022-07-14 - Support the root
 

--- a/octodns_route53/auth.py
+++ b/octodns_route53/auth.py
@@ -2,6 +2,8 @@
 #
 #
 
+import re
+
 from boto3 import client
 from botocore.config import Config
 
@@ -13,6 +15,7 @@ class _AuthMixin:
         access_key_id,
         secret_access_key,
         session_token,
+        role_arn,
         client_max_attempts,
         *args,
         **kwargs,
@@ -25,6 +28,28 @@ class _AuthMixin:
             session_token is not None,
             client_max_attempts,
         )
+
+        if role_arn:
+            self.log.debug('client:   assuming role %s', role_arn)
+            sts_client = self.client(
+                'sts',
+                access_key_id,
+                secret_access_key,
+                session_token,
+                None,
+                client_max_attempts,
+                *args,
+                **kwargs,
+            )
+
+            ident = re.sub(r"[^a-zA-Z0-9_=,.@-]+", "-", self.id)
+
+            credentials = sts_client.assume_role(
+                RoleArn=role_arn, RoleSessionName="octodns-route53-" + ident
+            )
+            access_key_id = credentials['Credentials']['AccessKeyId']
+            secret_access_key = credentials['Credentials']['SecretAccessKey']
+            session_token = credentials['Credentials']['Expiration']
 
         use_fallback_auth = (
             access_key_id is None

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -775,6 +775,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
         max_changes=1000,
         client_max_attempts=None,
         session_token=None,
+        role_arn=None,
         delegation_set_id=None,
         get_zones_by_name=False,
         *args,
@@ -800,6 +801,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
             session_token=session_token,
+            role_arn=role_arn,
             client_max_attempts=client_max_attempts,
         )
 

--- a/octodns_route53/source.py
+++ b/octodns_route53/source.py
@@ -23,6 +23,7 @@ class Ec2Source(_AuthMixin, BaseSource):
         access_key_id=None,
         secret_access_key=None,
         session_token=None,
+        role_arn=None,
         client_max_attempts=None,
         ttl=3600,
         tag_prefix='octodns',
@@ -48,6 +49,7 @@ class Ec2Source(_AuthMixin, BaseSource):
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
             session_token=session_token,
+            role_arn=role_arn,
             client_max_attempts=client_max_attempts,
             region_name=region,
         )
@@ -193,6 +195,7 @@ class ElbSource(_AuthMixin, BaseSource):
         access_key_id=None,
         secret_access_key=None,
         session_token=None,
+        role_arn=None,
         client_max_attempts=None,
         ttl=3600,
         tag_prefix='octodns',
@@ -218,6 +221,7 @@ class ElbSource(_AuthMixin, BaseSource):
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
             session_token=session_token,
+            role_arn=role_arn,
             client_max_attempts=client_max_attempts,
             region_name=region,
         )


### PR DESCRIPTION
This allows the client to assume a different role than the default IAM scope supplied by the initial credentials (either those passed as arguments or from the environment).

The use case for this is working with multiple accounts -- you issue credentials from a octo controller role which can assume a role in each account.

```yaml
  # Account #1
  route53-012345678900:
    class: octodns_route53.Route53Provider
    role_arn: arn:aws:iam::012345678900:role/octo-dns/octo-dns-agent

  # Account #2
  route53-012345678901:
    class: octodns_route53.Route53Provider
    role_arn: arn:aws:iam::012345678901:role/octo-dns/octo-dns-agent

  # Account #3
  route53-012345678902:
    class: octodns_route53.Route53Provider
    role_arn: arn:aws:iam::012345678902:role/octo-dns/octo-dns-agent
```