### PR TITLE
Implement Provider.list_zones for dynamic zone config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## v0.0.6 - 2022-??-?? -
 
-* Fixed issue with creating TCP healthchecks for dynamic CNAME records
+### Important
+
+* Adds Provider.list_zones to enable new dynamic zone config functionality
 * Ec2Source added to support dynamically creating records for Ec2 instances
 * ElbSource added to support dynamically creating records for ELBs
 * role_name added to auth mix-in to support acquiring a specific role from existing credentials 
+
+### Misc
+
+* Fixed issue with creating TCP healthchecks for dynamic CNAME records
 
 ## v0.0.5 - 2022-07-14 - Support the root
 

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1178,6 +1178,22 @@ class Route53Provider(_AuthMixin, BaseProvider):
 
         return super()._process_desired_zone(desired)
 
+    def list_zones(self):
+        self.log.debug('list_zones:')
+        hosted_zones = []
+        params = {}
+        if self.delegation_set_id:
+            params['DelegationSetId'] = self.delegation_set_id
+        more = True
+        while more:
+            resp = self._conn.list_hosted_zones(**params)
+            hosted_zones.extend([h['Name'] for h in resp['HostedZones']])
+            params['Marker'] = resp.get('NextMarker', None)
+            more = resp['IsTruncated']
+
+        hosted_zones.sort()
+        return hosted_zones
+
     def populate(self, zone, target=False, lenient=False):
         self.log.debug(
             'populate: name=%s, target=%s, lenient=%s',


### PR DESCRIPTION
Adds Provider.list_zones method to allow using Ns1Provider as a source of dynamic zone configs.

/cc https://github.com/octodns/octodns/pull/1026 for base functionality that will utilize this