### PR TITLE
Skip Traffic Policy records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Ec2Source added to support dynamically creating records for Ec2 instances
 * ElbSource added to support dynamically creating records for ELBs
 * role_name added to auth mix-in to support acquiring a specific role from existing credentials 
+* Warn and skip records with TrafficPolicyInstanceId as they're not supported
 
 ### Misc
 

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1234,7 +1234,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     else:
                         aliases[record_name].append(rrset)
                     continue
-                if 'TrafficPolicyInstanceId' in rrset:
+                elif 'TrafficPolicyInstanceId' in rrset:
                     self.log.warning('TrafficPolicies are not supported, skipping %s', rrset['Name'])
                     continue
                 # A basic record (potentially including geo)

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1234,6 +1234,9 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     else:
                         aliases[record_name].append(rrset)
                     continue
+                if 'TrafficPolicyInstanceId' in rrset:
+                    self.log.warning('TrafficPolicies are not supported, skipping %s', rrset['Name'])
+                    continue
                 # A basic record (potentially including geo)
                 data = getattr(self, f'_data_for_{record_type}')(rrset)
                 records[record_name][record_type].append(data)

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1235,7 +1235,10 @@ class Route53Provider(_AuthMixin, BaseProvider):
                         aliases[record_name].append(rrset)
                     continue
                 elif 'TrafficPolicyInstanceId' in rrset:
-                    self.log.warning('TrafficPolicies are not supported, skipping %s', rrset['Name'])
+                    self.log.warning(
+                        'TrafficPolicies are not supported, skipping %s',
+                        rrset['Name'],
+                    )
                     continue
                 # A basic record (potentially including geo)
                 data = getattr(self, f'_data_for_{record_type}')(rrset)

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -1023,6 +1023,12 @@ class TestRoute53Provider(TestCase):
                     'ResourceRecords': [{'Value': '7.2.3.4'}],
                     'TTL': 61,
                 },
+                {
+                    'Name': 'ignored.unit.tests.',
+                    'TrafficPolicyInstanceId': 'foo',
+                    'TTL': 60,
+                    'Type': 'A',
+                },
             ],
             'IsTruncated': True,
             'NextRecordName': 'next_name',


### PR DESCRIPTION
Skipping unsupported Traffic Policy records.

Relates to this issue: https://github.com/octodns/octodns/issues/990