### PR TITLE
Add tag append parameter to sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.0.7 - 2023-??-?? - 
+
+### Important
+
+* Add `append_to_names` tag append parameter to sources
+
 ## v0.0.6 - 2023-10-16 - Long overdue
 
 ### Important

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ providers:
     region: us-east-1
     # Prefix for tag keys containing fqdn(s)
     #tag_prefix: octodns
+    # String to append to all names and tag values
+    #append_to_names: mydomain.com.
     #ttl: 3600
 ```
 
@@ -71,7 +73,7 @@ In general the account used will need read permissions on EC2 instances.
 
 Records are driven off of the tags attached to the EC2 instances. The "Name" tag and any tags starting with `tag_prefix` are considered.
 
-The value of the tag should be one or more fqdns separated by a `/` character.
+The value of the tag should be one or more fqdns separated by a `/` character. You can append a string to the name and all tag values with `append_to_names`.
 
 When a zone is being populated any fqdns matching the zone name will result in records. When the instance has a private IPv4 address an A record will be created. When the instance has an IPv6 address a AAAA record will be created.
 
@@ -92,6 +94,8 @@ providers:
     region: us-east-1
     # Prefix for tag keys containing fqdn(s)
     #tag_prefix: octodns
+    # String to append to all names and tag values
+    #append_to_names: mydomain.com.
     #ttl: 3600
 ```
 
@@ -99,7 +103,7 @@ In general the account used will need read permissions on ELB instances and tags
 
 Records are driven off of the ELB name and the tags attached to the ELB instances. Any tag with `tag_prefix` is considered.
 
-The value of the tag should be one or more fqdns separated by a `/` character.
+The value of the tag should be one or more fqdns separated by a `/` character. You can append a string to the name and all tag values with `append_to_names`.
 
 When a zone is being populated any fqdns matching the zone name will result in records CNAME records with the target value being the DNSName of the ELB instance.
 

--- a/octodns_route53/source.py
+++ b/octodns_route53/source.py
@@ -27,20 +27,23 @@ class Ec2Source(_AuthMixin, BaseSource):
         client_max_attempts=None,
         ttl=3600,
         tag_prefix='octodns',
+        append_to_names="",
         *args,
         **kwargs,
     ):
         self.log = getLogger(f'Ec2Source[{id}]')
         self.log.info(
-            '__init__: id=%s, region=%s, access_key_id=%s, ttl=%d, tag_prefix=%s',
+            '__init__: id=%s, region=%s, access_key_id=%s, ttl=%d, tag_prefix=%s, append_to_names=%s',
             id,
             region,
             access_key_id,
             ttl,
             tag_prefix,
+            append_to_names,
         )
         self.ttl = ttl
         self.tag_prefix = tag_prefix
+        self.append_to_names = append_to_names
 
         super().__init__(id, *args, **kwargs)
 
@@ -69,9 +72,12 @@ class Ec2Source(_AuthMixin, BaseSource):
                         key = tag['Key']
                         val = tag['Value']
                         if key == 'Name':
-                            fqdns.append(val)
+                            fqdns.append(val + self.append_to_names)
                         elif key.startswith(self.tag_prefix):
-                            fqdns.extend(val.split('/'))
+                            fqdns.extend(
+                                fqdn + self.append_to_names
+                                for fqdn in val.split('/')
+                            )
 
                     fqdns = [f'{i}.' if i[-1] != '.' else i for i in fqdns]
                     instances[instance['InstanceId']] = {
@@ -199,20 +205,23 @@ class ElbSource(_AuthMixin, BaseSource):
         client_max_attempts=None,
         ttl=3600,
         tag_prefix='octodns',
+        append_to_names="",
         *args,
         **kwargs,
     ):
         self.log = getLogger(f'ElbSource[{id}]')
         self.log.info(
-            '__init__: id=%s, region=%s, access_key_id=%s, ttl=%d, tag_prefix=%s',
+            '__init__: id=%s, region=%s, access_key_id=%s, ttl=%d, tag_prefix=%s, append_to_names=%s',
             id,
             region,
             access_key_id,
             ttl,
             tag_prefix,
+            append_to_names,
         )
         self.ttl = ttl
         self.tag_prefix = tag_prefix
+        self.append_to_names = append_to_names
 
         super().__init__(id, *args, **kwargs)
 
@@ -238,7 +247,7 @@ class ElbSource(_AuthMixin, BaseSource):
                 arn = lb['LoadBalancerArn']
                 lbs[arn] = {
                     'dns_name': f'{lb["DNSName"]}.',
-                    'fqdns': [lb['LoadBalancerName']],
+                    'fqdns': [lb['LoadBalancerName'] + self.append_to_names],
                 }
 
             # request tags and look through them for fqdns
@@ -252,7 +261,10 @@ class ElbSource(_AuthMixin, BaseSource):
                         key = tag['Key']
                         val = tag['Value']
                         if key.startswith(self.tag_prefix):
-                            lb['fqdns'].extend(val.split('/'))
+                            lb['fqdns'].extend(
+                                fqdn + self.append_to_names
+                                for fqdn in val.split('/')
+                            )
 
             for lb in lbs.values():
                 fqdns = lb['fqdns']

--- a/tests/test_octodns_source_elb.py
+++ b/tests/test_octodns_source_elb.py
@@ -12,6 +12,87 @@ from octodns_route53 import ElbSource
 
 
 class TestElbSource(TestCase):
+    load_balancers = {
+        'LoadBalancers': [
+            {
+                # matches name
+                'DNSName': 'foo.aws.com',
+                'LoadBalancerArn': 'arn42',
+                'LoadBalancerName': 'service.unit.tests.',
+            },
+            {
+                # doesn't match
+                'DNSName': 'bar.aws.com',
+                'LoadBalancerArn': 'arn43',
+                'LoadBalancerName': 'this.doesnt.match.',
+            },
+            {
+                # matches, no trailing dot
+                'DNSName': 'baz.aws.com',
+                'LoadBalancerArn': 'arn44',
+                'LoadBalancerName': 'no-dot.unit.tests',
+            },
+            {
+                # name doesn't match, but tags will
+                'DNSName': 'blip.aws.com',
+                'LoadBalancerArn': 'arn45',
+                'LoadBalancerName': 'tags.will.match.',
+            },
+            {
+                # both name and tags match
+                'DNSName': 'bang.aws.com',
+                'LoadBalancerArn': 'arn46',
+                'LoadBalancerName': 'both.unit.tests.',
+            },
+        ]
+    }
+    tags = {
+        'TagDescriptions': [
+            {
+                'ResourceArn': 'arn42',
+                'Tags': [{'Key': 'irrelevant', 'Value': 'doesnt matter'}],
+            },
+            {'ResourceArn': 'arn43'},
+            {'ResourceArn': 'arn44'},
+            {
+                'ResourceArn': 'arn45',
+                'Tags': [
+                    {
+                        'Key': 'octodns',
+                        # multi-value: one matches w/dot. one matches w/o dot, one
+                        # doesn't match
+                        'Value': 'first.unit.tests./second.unit.tests/third.thing.',
+                    }
+                ],
+            },
+            {
+                'ResourceArn': 'arn46',
+                'Tags': [
+                    {
+                        'Key': 'octodns-1',
+                        # matches
+                        'Value': 'fourth.unit.tests.',
+                    },
+                    {
+                        'Key': 'octodns-2',
+                        # matches w/o dot
+                        'Value': 'fifth.unit.tests',
+                    },
+                    {
+                        'Key': 'octodns-2',
+                        # doesn't match
+                        'Value': 'sixth.doesnt.apply.',
+                    },
+                    {
+                        'Key': 'octodns-3',
+                        # apex match
+                        'Value': 'unit.tests.',
+                    },
+                ],
+            },
+        ]
+    }
+
     def _get_stubbed_source(self, **kwargs):
         source = ElbSource('test', 'us-east-1', 'abc', '123', **kwargs)
 
@@ -41,95 +122,9 @@ class TestElbSource(TestCase):
 
         zone = Zone('unit.tests.', [])
 
-        stubber.add_response(
-            'describe_load_balancers',
-            {
-                'LoadBalancers': [
-                    {
-                        # matches name
-                        'DNSName': 'foo.aws.com',
-                        'LoadBalancerArn': 'arn42',
-                        'LoadBalancerName': 'service.unit.tests.',
-                    },
-                    {
-                        # doesn't match
-                        'DNSName': 'bar.aws.com',
-                        'LoadBalancerArn': 'arn43',
-                        'LoadBalancerName': 'this.doesnt.match.',
-                    },
-                    {
-                        # matches, no trailing dot
-                        'DNSName': 'baz.aws.com',
-                        'LoadBalancerArn': 'arn44',
-                        'LoadBalancerName': 'no-dot.unit.tests',
-                    },
-                    {
-                        # name doesn't match, but tags will
-                        'DNSName': 'blip.aws.com',
-                        'LoadBalancerArn': 'arn45',
-                        'LoadBalancerName': 'tags.will.match.',
-                    },
-                    {
-                        # both name and tags match
-                        'DNSName': 'bang.aws.com',
-                        'LoadBalancerArn': 'arn46',
-                        'LoadBalancerName': 'both.unit.tests.',
-                    },
-                ]
-            },
-        )
+        stubber.add_response('describe_load_balancers', self.load_balancers)
 
-        stubber.add_response(
-            'describe_tags',
-            {
-                'TagDescriptions': [
-                    {
-                        'ResourceArn': 'arn42',
-                        'Tags': [
-                            {'Key': 'irrelevant', 'Value': 'doesnt matter'}
-                        ],
-                    },
-                    {'ResourceArn': 'arn43'},
-                    {'ResourceArn': 'arn44'},
-                    {
-                        'ResourceArn': 'arn45',
-                        'Tags': [
-                            {
-                                'Key': 'octodns',
-                                # multi-value: one matches w/dot. one matches w/o dot, one
-                                # doesn't match
-                                'Value': 'first.unit.tests./second.unit.tests/third.thing.',
-                            }
-                        ],
-                    },
-                    {
-                        'ResourceArn': 'arn46',
-                        'Tags': [
-                            {
-                                'Key': 'octodns-1',
-                                # matches
-                                'Value': 'fourth.unit.tests.',
-                            },
-                            {
-                                'Key': 'octodns-2',
-                                # matches w/o dot
-                                'Value': 'fifth.unit.tests',
-                            },
-                            {
-                                'Key': 'octodns-2',
-                                # doesn't match
-                                'Value': 'sixth.doesnt.apply.',
-                            },
-                            {
-                                'Key': 'octodns-3',
-                                # apex match
-                                'Value': 'unit.tests.',
-                            },
-                        ],
-                    },
-                ]
-            },
-        )
+        stubber.add_response('describe_tags', self.tags)
 
         source.populate(zone)
 


### PR DESCRIPTION
I've added an optional ~~`tag_append`~~ `append_to_names` parameter to the sources here. We are using this to avoid the need to rename all of our EC2 instances to append our domain, among other purposes.