### PR TITLE
_Route53AliasValue needs to use - not _

### DIFF
--- a/octodns_route53/record.py
+++ b/octodns_route53/record.py
@@ -48,19 +48,19 @@ class _Route53AliasValue(EqualityTupleMixin, dict):
 
     @property
     def evaluate_target_health(self):
-        return self['evaluate_target_health']
+        return self['evaluate-target-health']
 
     @evaluate_target_health.setter
     def evaluate_target_health(self, value):
-        self['evaluate_target_health'] = value
+        self['evaluate-target-health'] = value
 
     @property
     def hosted_zone_id(self):
-        return self['hosted_zone_id']
+        return self['hosted-zone-id']
 
     @hosted_zone_id.setter
     def hosted_zone_id(self, value):
-        self['hosted_zone_id'] = value
+        self['hosted-zone-id'] = value
 
     @property
     def data(self):

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -4318,6 +4318,9 @@ class TestRoute53AliasRecord(TestCase):
             v0.data,
         )
 
+        self.assertTrue('evaluate-target-health' in v0.data)
+        self.assertTrue('hosted-zone-id' in v0.data)
+
         self.assertEqual(hash(v0), hash(v0))
         self.assertEqual(hash(v1), hash(v1))
         self.assertNotEqual(hash(v0), hash(v1))


### PR DESCRIPTION
Regression introduced with #41, thankfully @web-xyz ran into it and reported it before we'd cut a release (some upside to not having released in a long time.)

/cc Fixes https://github.com/octodns/octodns-route53/issues/72
/cc #41 which introduced the bug