### PR TITLE
Fix role authentication to use the session token correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `append_to_names` tag append parameter to sources
 * Add `DS` record type support
+* Updated role authentication to use the correct session token value
 
 ## v0.0.6 - 2023-10-16 - Long overdue
 

--- a/octodns_route53/auth.py
+++ b/octodns_route53/auth.py
@@ -58,7 +58,7 @@ class _AuthMixin:
             # client with the new auth
             access_key_id = credentials['Credentials']['AccessKeyId']
             secret_access_key = credentials['Credentials']['SecretAccessKey']
-            session_token = credentials['Credentials']['Expiration']
+            session_token = credentials['Credentials']['SessionToken']
 
         use_fallback_auth = (
             access_key_id is None

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -861,6 +861,7 @@ class TestRoute53Provider(TestCase):
                     'AccessKeyId': 42,
                     'SecretAccessKey': 43,
                     'Expiration': 44,
+                    'SessionToken': 45,
                 }
             }
         ]
@@ -896,7 +897,7 @@ class TestRoute53Provider(TestCase):
                     service_name='route53',
                     aws_access_key_id=42,
                     aws_secret_access_key=43,
-                    aws_session_token=44,
+                    aws_session_token=45,
                     config=None,
                 ),
             ]


### PR DESCRIPTION
Authenticating using an IAM role currently gives this error:
> AttributeError: 'datetime.datetime' object has no attribute 'split'

That's due to us passing a datetime object through instead of what should be a string containing the session token.

Switching to using the SessionToken value instead makes it complete as expected.