### PR TITLE
Version 0.0.7 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.7 - 2023-??-?? - 
+## v0.0.7 - 2024-04-11 - Helps if you use the actual Session token
 
 ### Important
 

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -7,7 +7,7 @@ from .record import Route53AliasRecord
 from .source import Ec2Source, ElbSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.6'
+__version__ = __VERSION__ = '0.0.7'
 
 # quell warnings
 Ec2Source


### PR DESCRIPTION
## v0.0.7 - 2024-04-11 - Helps if you use the actual Session token

### Important

* Add `append_to_names` tag append parameter to sources
* Add `DS` record type support
* Updated role authentication to use the correct session token value