### PR TITLE
Rework cibuild-setup-py to build a pkg and install & test it

### DIFF
--- a/script/cibuild-setup-py
+++ b/script/cibuild-setup-py
@@ -3,18 +3,20 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+VERSION="$(grep "^__version__" "./octodns_route53/__init__.py" | sed -e "s/.* = '//" -e "s/'$//")"
+
 echo "## create test venv ############################################################"
 TMP_DIR=$(mktemp -d -t ci-XXXXXXXXXX)
 python3 -m venv $TMP_DIR
 . "$TMP_DIR/bin/activate"
-pip install setuptools
+pip install build setuptools
 echo "## environment & versions ######################################################"
 python --version
 pip --version
 echo "## validate setup.py build #####################################################"
-python setup.py build
-echo "## validate setup.py install ###################################################"
-python setup.py install
+python -m build --sdist --wheel
+echo "## validate wheel install ###################################################"
+pip install dist/*$VERSION*.whl
 echo "## validate tests can run against installed code ###############################"
 pip install pytest pytest-network
 pytest --disable-network


### PR DESCRIPTION
pip env doesn't seem to like python setup installing thing into it anymore and prints a bunch of deprecation warnings and something is already broken, at least w/google modules, that prevents them from loading afterwards

/cc https://github.com/octodns/octodns-googlecloud/pull/48
