### PR TITLE
Fix CAA records whitespace splitting with additional optional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.? - 2024-??-?? - 
+
+* Fix CAA rdata parsing to allow values with tags
+
 ## v0.0.7 - 2024-04-11 - Helps if you use the actual Session token
 
 ### Important

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -913,7 +913,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
     def _data_for_CAA(self, rrset):
         values = []
         for rr in rrset['ResourceRecords']:
-            flags, tag, value = rr['Value'].split()
+            flags, tag, value = rr['Value'].split(' ', 2)
             values.append({'flags': flags, 'tag': tag, 'value': value[1:-1]})
         return {
             'type': rrset['Type'],

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -401,7 +401,11 @@ class TestRoute53Provider(TestCase):
             {
                 'ttl': 69,
                 'type': 'CAA',
-                'value': {'flags': 0, 'tag': 'issue', 'value': 'ca.unit.tests; cansignhttpexchanges=yes'},
+                'value': {
+                    'flags': 0,
+                    'tag': 'issue',
+                    'value': 'ca.unit.tests; cansignhttpexchanges=yes',
+                },
             },
         ),
         (
@@ -1125,7 +1129,11 @@ class TestRoute53Provider(TestCase):
                 {
                     'Name': 'unit.tests.',
                     'Type': 'CAA',
-                    'ResourceRecords': [{'Value': '0 issue "ca.unit.tests; cansignhttpexchanges=yes"'}],
+                    'ResourceRecords': [
+                        {
+                            'Value': '0 issue "ca.unit.tests; cansignhttpexchanges=yes"'
+                        }
+                    ],
                     'TTL': 69,
                 },
                 {

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -401,7 +401,7 @@ class TestRoute53Provider(TestCase):
             {
                 'ttl': 69,
                 'type': 'CAA',
-                'value': {'flags': 0, 'tag': 'issue', 'value': 'ca.unit.tests'},
+                'value': {'flags': 0, 'tag': 'issue', 'value': 'ca.unit.tests; cansignhttpexchanges=yes'},
             },
         ),
         (
@@ -1125,7 +1125,7 @@ class TestRoute53Provider(TestCase):
                 {
                     'Name': 'unit.tests.',
                     'Type': 'CAA',
-                    'ResourceRecords': [{'Value': '0 issue "ca.unit.tests"'}],
+                    'ResourceRecords': [{'Value': '0 issue "ca.unit.tests; cansignhttpexchanges=yes"'}],
                     'TTL': 69,
                 },
                 {


### PR DESCRIPTION
- Currently, if there are additional properties inside of the CAA record that are separated by a whitespace, the provider will fail with the following error message:

```log
2024-05-04T15:40:27  [140469743658816] INFO  Manager dump: using custom YamlProvider
Traceback (most recent call last):
  File "/home/james/dev/python/octodns/env/bin/octodns-dump", line 8, in <module>
    sys.exit(main())
  File "/home/james/dev/python/octodns/env/lib/python3.10/site-packages/octodns/cmds/dump.py", line 51, in main
    manager.dump(
  File "/home/james/dev/python/octodns/env/lib/python3.10/site-packages/octodns/manager.py", line 969, in dump
    source.populate(zone, lenient=lenient)
  File "/home/james/dev/python/octodns/env/lib/python3.10/site-packages/octodns_route53/provider.py", line 1272, in populate
    data = getattr(self, f'_data_for_{record_type}')(rrset)
  File "/home/james/dev/python/octodns/env/lib/python3.10/site-packages/octodns_route53/provider.py", line 916, in _data_for_CAA
    flags, tag, value = rr['Value'].split()
ValueError: too many values to unpack (expected 3)
```
- Per RFC 6844 section 5.2 [1], whitespace separation of optional parameters inside of the value is valid and the suggested syntax.
[1] https://www.rfc-editor.org/rfc/rfc6844.txt
```
5.2.  CAA issue Property

   The issue property tag is used to request that certificate issuers
   perform CAA issue restriction processing for the domain and to grant
   authorization to specific certificate issuers.

   The CAA issue property value has the following sub-syntax (specified
   in ABNF as per [RFC5234]).

   issuevalue  = space [domain] space [";" *(space parameter) space]

   domain = label *("." label)
   label = (ALPHA / DIGIT) *( *("-") (ALPHA / DIGIT))

   space = *(SP / HTAB)

   parameter =  tag "=" value

   tag = 1*(ALPHA / DIGIT)

   value = *VCHAR

   For consistency with other aspects of DNS administration, domain name
   values are specified in letter-digit-hyphen Label (LDH-Label) form.
```
- This fix uses the `split(..., maxsplit)` parameter, to ensure that we only split the first 2 whitespace characters between the FIELD, TAG and VALUE, whilst leaving any additional whitespace untouched.

*Note*:
(This is my first public pull request -- lint was successful and test coverage passes. Please let me know if I have missed anything).

```
octodns-route53 on  fix-caa-records-whitespace-split [!?] via 🐍 v3.10.12 (env) via ❄️  impure (shell) 
❯ ./script/lint
echo $
octodns-route53 on  fix-caa-records-whitespace-split [!?] via 🐍 v3.10.12 (env) via ❄️  impure (shell) 
❯ echo $?
0

octodns-route53 on  fix-caa-records-whitespace-split [!?] via 🐍 v3.10.12 (env) via ❄️  impure (shell) 
❯ ./script/coverage
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.10.12, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/jmitterm/dev/python/octodns/providers_source/octodns-route53
configfile: pyproject.toml
plugins: typeguard-2.13.3, network-0.0.1, cov-5.0.0, mock-3.14.0
collected 63 items                                                                                                                                                                                                                                           

tests/test_octodns_provider_route53.py .....................................................                                                                                                                                                           [ 84%]
tests/test_octodns_source_ec2.py ......                                                                                                                                                                                                                [ 93%]
tests/test_octodns_source_elb.py ....                                                                                                                                                                                                                  [100%]

---------- coverage: platform linux, python 3.10.12-final-0 ----------
Name                                    Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------------
octodns_route53/__init__.py                 9      0      0      0   100%
octodns_route53/auth.py                    24      0      8      0   100%
octodns_route53/processor/__init__.py      14      0      4      0   100%
octodns_route53/provider.py               846      0    322      0   100%
octodns_route53/record.py                  69      0     18      0   100%
octodns_route53/source.py                 138      0     74      0   100%
-------------------------------------------------------------------------
TOTAL                                    1100      0    426      0   100%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

Required test coverage of 100% reached. Total coverage: 100.00%

===================================================================================================================== 63 passed in 1.15s =====================================================================================================================

octodns-route53 on  fix-caa-records-whitespace-split [!?] via 🐍 v3.10.12 (env) via ❄️  impure (shell)
```