### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0 - 2024-??-?? - ???
+## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 ### Notedworthy Changes:
 

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -7,7 +7,7 @@ from .record import Route53AliasRecord
 from .source import Ec2Source, ElbSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.7'
+__version__ = __VERSION__ = '1.0.0'
 
 # quell warnings
 Ec2Source


### PR DESCRIPTION
# v1.0.0 - 2025-05-04 - Long overdue 1.0

### Notedworthy Changes:

* `geo` record support removed, records should be migrated to `dynamic` before
  upgrading.
* `SPF` record support removed, records should be migrated to `TXT` before
  upgrading.
* Requires octoDNS >= 1.5.0

### Other Changes:

* Fix CAA rdata parsing to allow values with tags
* Validate that healthcheck protocol is supported (HTTP, HTTPS, TCP)