### PR TITLE
Version 1.0.1 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.1 - 2025-05-?? - Only clamp when forced
+## v1.0.1 - 2025-05-05 - Only clamp when forced
 
 * Don't clamp urllib3 unless we're on 3.8 or 3.9 where it's actually needed
 

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -7,7 +7,7 @@ from .record import Route53AliasRecord
 from .source import Ec2Source, ElbSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 # quell warnings
 Ec2Source


### PR DESCRIPTION
## v1.0.1 - 2025-05-05 - Only clamp when forced

* Don't clamp urllib3 unless we're on 3.8 or 3.9 where it's actually needed
