### PR TITLE
AWS Profiles support for Route53 Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ providers:
     # The AWS session token (optional)
     # Only needed if using temporary security credentials
     #session_token: env/AWS_SESSION_TOKEN
+    # The AWS profile name (optional)
+    #profile:
 ```
 
 Alternatively, you may leave out access_key_id, secret_access_key and session_token.  This will result in boto3 deciding authentication dynamically.

--- a/octodns_route53/auth.py
+++ b/octodns_route53/auth.py
@@ -82,7 +82,7 @@ class _AuthMixin:
         if profile is not None:
             session_kwargs['profile_name'] = profile
 
-        if use_fallback_auth:
+        if not use_fallback_auth:
             session_kwargs['aws_access_key_id'] = access_key_id
             session_kwargs['aws_secret_access_key'] = secret_access_key
             session_kwargs['aws_session_token'] = session_token
@@ -90,8 +90,5 @@ class _AuthMixin:
         session = Session(**session_kwargs)
 
         return session.client(
-            *args,
-            service_name=service_name,
-            config=config,
-            **kwargs,
+            *args, service_name=service_name, config=config, **kwargs
         )

--- a/octodns_route53/auth.py
+++ b/octodns_route53/auth.py
@@ -4,7 +4,7 @@
 
 import re
 
-from boto3 import client
+from boto3 import Session
 from botocore.config import Config
 
 
@@ -16,17 +16,19 @@ class _AuthMixin:
         secret_access_key,
         session_token,
         role_arn,
+        profile,
         client_max_attempts,
         *args,
         **kwargs,
     ):
         self.log.debug(
-            'client: service_name=%s, access_key_id=%s, secret_access_key=%s, session_token=%s, client_max_attempts=%s',
+            'client: service_name=%s, access_key_id=%s, secret_access_key=%s, session_token=%s, client_max_attempts=%s, profile=%s',
             service_name,
             access_key_id,
             secret_access_key is not None,
             session_token is not None,
             client_max_attempts,
+            profile,
         )
 
         if role_arn:
@@ -39,6 +41,7 @@ class _AuthMixin:
                 secret_access_key,
                 session_token,
                 None,
+                profile,
                 client_max_attempts,
                 *args,
                 **kwargs,
@@ -75,15 +78,20 @@ class _AuthMixin:
             )
             config = Config(retries={'max_attempts': client_max_attempts})
 
-        if use_fallback_auth:
-            return client(service_name, *args, config=config, **kwargs)
+        session_kwargs = {}
+        if profile is not None:
+            session_kwargs['profile_name'] = profile
 
-        return client(
+        if use_fallback_auth:
+            session_kwargs['aws_access_key_id'] = access_key_id
+            session_kwargs['aws_secret_access_key'] = secret_access_key
+            session_kwargs['aws_session_token'] = session_token
+
+        session = Session(**session_kwargs)
+
+        return session.client(
             *args,
             service_name=service_name,
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key,
-            aws_session_token=session_token,
             config=config,
             **kwargs,
         )

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -629,6 +629,8 @@ class Route53Provider(_AuthMixin, BaseProvider):
         # The AWS session token (optional)
         # Only needed if using temporary security credentials
         session_token:
+        # The AWS profile name (optional)
+        profile:
 
     Alternatively, you may leave out access_key_id, secret_access_key
     and session_token.
@@ -672,6 +674,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
         client_max_attempts=None,
         session_token=None,
         role_arn=None,
+        profile=None,
         delegation_set_id=None,
         get_zones_by_name=False,
         *args,
@@ -698,6 +701,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
             secret_access_key=secret_access_key,
             session_token=session_token,
             role_arn=role_arn,
+            profile=profile,
             client_max_attempts=client_max_attempts,
         )
 

--- a/octodns_route53/source.py
+++ b/octodns_route53/source.py
@@ -24,6 +24,7 @@ class Ec2Source(_AuthMixin, BaseSource):
         secret_access_key=None,
         session_token=None,
         role_arn=None,
+        profile=None,
         client_max_attempts=None,
         ttl=3600,
         tag_prefix='octodns',
@@ -53,6 +54,7 @@ class Ec2Source(_AuthMixin, BaseSource):
             secret_access_key=secret_access_key,
             session_token=session_token,
             role_arn=role_arn,
+            profile=profile,
             client_max_attempts=client_max_attempts,
             region_name=region,
         )
@@ -202,6 +204,7 @@ class ElbSource(_AuthMixin, BaseSource):
         secret_access_key=None,
         session_token=None,
         role_arn=None,
+        profile=None,
         client_max_attempts=None,
         ttl=3600,
         tag_prefix='octodns',
@@ -231,6 +234,7 @@ class ElbSource(_AuthMixin, BaseSource):
             secret_access_key=secret_access_key,
             session_token=session_token,
             role_arn=role_arn,
+            profile=profile,
             client_max_attempts=client_max_attempts,
             region_name=region,
         )

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -914,8 +914,19 @@ class TestRoute53Provider(TestCase):
             stubber.add_client_error('list_hosted_zones')
             provider.populate(got)
 
-    @patch('octodns_route53.auth.client')
-    def test_populate_with_role_acquisition(self, client_mock):
+    @patch('octodns_route53.auth.Session')
+    def test_leverage_named_profile(self, session_cls_mock):
+        session_mock = Mock()
+        session_mock.client.side_effect = [Mock()]
+        session_cls_mock.side_effect = [session_mock]
+        Route53Provider(id='test', profile="test-profile")
+        session_cls_mock.assert_called_once_with(profile_name="test-profile")
+        session_mock.client.assert_called_once_with(
+            service_name='route53', config=None
+        )
+
+    @patch('octodns_route53.auth.Session')
+    def test_populate_with_role_acquisition(self, session_cls_mock):
         # a mock so that when `assume_role` is called on it we get back new
         # assumed credentials
         assume_role_mock = Mock()
@@ -931,7 +942,11 @@ class TestRoute53Provider(TestCase):
         ]
         # first call will be for the STS client which needs to assume role,
         # the second call will be for the route53 client, it won't be used
-        client_mock.side_effect = [assume_role_mock, False]
+        session_mock1 = Mock()
+        session_mock1.client.side_effect = [assume_role_mock]
+        session_mock2 = Mock()
+        session_mock2.client.side_effect = [Mock()]
+        session_cls_mock.side_effect = [session_mock1, session_mock2]
         # now create our provider
         role_arn = 'arn:aws:iam:12345:role/foo'
         Route53Provider(
@@ -941,30 +956,28 @@ class TestRoute53Provider(TestCase):
             role_arn=role_arn,
         )
         # make sure assume role was called with the exepected role_arn
-        assume_role_mock.assume_role.assert_called_once_with(
-            RoleArn=role_arn, RoleSessionName='octodns-route53-test'
-        )
-        # make sure we had 2 calls to get clients
-        client_mock.assert_has_calls(
+        session_cls_mock.assert_has_calls(
             [
-                # the first time with the base params to get a STS client
                 call(
-                    service_name='sts',
                     aws_access_key_id='abc',
                     aws_secret_access_key='123',
                     aws_session_token=None,
-                    config=None,
                 ),
-                # the second time, with the assumed role's key, secret,
-                # and session, this time to gets the actual route53 client
                 call(
-                    service_name='route53',
                     aws_access_key_id=42,
                     aws_secret_access_key=43,
                     aws_session_token=45,
-                    config=None,
                 ),
             ]
+        )
+        assume_role_mock.assume_role.assert_called_once_with(
+            RoleArn=role_arn, RoleSessionName='octodns-route53-test'
+        )
+        session_mock1.client.assert_called_once_with(
+            service_name='sts', config=None
+        )
+        session_mock2.client.assert_called_once_with(
+            service_name='route53', config=None
         )
 
     def test_list_zones(self):


### PR DESCRIPTION
This pull request introduces support for AWS named profiles in the octodns_route53 provider, enhancing flexibility in credential management when interacting with AWS Route53. By allowing users to specify a profile field in the provider configuration, the provider can now leverage credentials stored in the local AWS configuration file (~/.aws/config and ~/.aws/credentials), which is a common practice for managing access across multiple AWS accounts and roles:

https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html#cli-configure-files-using-profiles

This change is backward-compatible and does not alter existing behavior for users who continue to use static credentials or rely on boto3’s dynamic credential resolution.