### PR TITLE
Support for restricting zone lookup to private or public hosted zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.?.? - 2025-??-?? - ???
+
+* Multiple zones with the same name will now throw an error message, behavior
+  previously would not have been deterministic.
+* New provider paramater, private, added to enable specifying zone type. Note
+  that VPC associations are managed.
+
 ## v1.0.1 - 2025-05-05 - Only clamp when forced
 
 * Don't clamp urllib3 unless we're on 3.8 or 3.9 where it's actually needed

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ providers:
     #session_token: env/AWS_SESSION_TOKEN
     # The AWS profile name (optional)
     #profile:
+    # Optionally restrict hosted zone lookup to only private or public zones.
+    # If zone creation is required and this option is set, zones will be created as private.
+    # Set to true to only use private zones, false for public zones, or omit for no restriction.
+    #private: False
 ```
 
 Alternatively, you may leave out access_key_id, secret_access_key and session_token.  This will result in boto3 deciding authentication dynamically.

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -608,6 +608,17 @@ class TestRoute53Provider(TestCase):
 
         return (provider, stubber)
 
+    def _get_stubbed_private_provider(self):
+        provider = Route53Provider(
+            'test', 'abc', '123', strict_supports=False, private=True
+        )
+
+        # Use the stubber
+        stubber = Stubber(provider._conn)
+        stubber.activate()
+
+        return (provider, stubber)
+
     def _get_stubbed_fallback_auth_provider(self):
         provider = Route53Provider('test', strict_supports=False)
 
@@ -650,6 +661,36 @@ class TestRoute53Provider(TestCase):
 
         provider.update_r53_zones("unit.tests.")
         self.assertEqual(provider._r53_zones, {'unit.tests.': 'z40'})
+
+    def test_update_r53_zones_private(self):
+        provider, stubber = self._get_stubbed_private_provider()
+
+        list_hosted_zones = {
+            'HostedZones': [
+                {
+                    'Id': 'z40',
+                    'Name': 'unit.tests.',
+                    'CallerReference': 'abc',
+                    'Config': {'Comment': 'string', 'PrivateZone': False},
+                    'ResourceRecordSetCount': 123,
+                },
+                {
+                    'Id': 'z41',
+                    'Name': 'private.unit.tests.',
+                    'CallerReference': 'abc',
+                    'Config': {'Comment': 'string', 'PrivateZone': True},
+                    'ResourceRecordSetCount': 123,
+                },
+            ],
+            'Marker': 'm',
+            'IsTruncated': False,
+            'MaxItems': '100',
+        }
+
+        stubber.add_response('list_hosted_zones', list_hosted_zones)
+
+        provider.update_r53_zones("unit.tests.")
+        self.assertEqual(provider._r53_zones, {'private.unit.tests.': 'z41'})
 
     def test_update_r53_zones_with_get_zones_by_name(self):
         (provider, stubber) = (
@@ -994,6 +1035,31 @@ class TestRoute53Provider(TestCase):
         }
         stubber.add_response('list_hosted_zones', list_hosted_zones_resp, {})
         self.assertEqual(['alpha.com.', 'unit.tests.'], provider.list_zones())
+
+    def test_list_private_zones(self):
+        provider, stubber = self._get_stubbed_private_provider()
+
+        list_hosted_zones_resp = {
+            'HostedZones': [
+                {
+                    'Name': 'unit.tests.',
+                    'Id': 'z42',
+                    'CallerReference': 'abc',
+                    'Config': {'PrivateZone': False},
+                },
+                {
+                    'Name': 'alpha.com.',
+                    'Id': 'z43',
+                    'CallerReference': 'abd',
+                    'Config': {'PrivateZone': True},
+                },
+            ],
+            'Marker': '',
+            'IsTruncated': False,
+            'MaxItems': '100',
+        }
+        stubber.add_response('list_hosted_zones', list_hosted_zones_resp, {})
+        self.assertEqual(['alpha.com.'], provider.list_zones())
 
     def test_delegated_list_zones(self):
         provider, stubber = self._get_stubbed_delegation_set_provider()
@@ -1530,6 +1596,100 @@ class TestRoute53Provider(TestCase):
                 'Name': got.name,
                 'CallerReference': ANY,
                 'DelegationSetId': 'ABCDEFG123456',
+            },
+        )
+
+        list_resource_record_sets_resp = {
+            'ResourceRecordSets': [
+                {
+                    'Name': 'a.unit.tests.',
+                    'Type': 'A',
+                    'GeoLocation': {'ContinentCode': 'NA'},
+                    'ResourceRecords': [{'Value': '2.2.3.4'}],
+                    'TTL': 61,
+                }
+            ],
+            'IsTruncated': False,
+            'MaxItems': '100',
+        }
+        stubber.add_response(
+            'list_resource_record_sets',
+            list_resource_record_sets_resp,
+            {'HostedZoneId': 'z42'},
+        )
+
+        stubber.add_response(
+            'list_health_checks',
+            {
+                'HealthChecks': self.health_checks,
+                'IsTruncated': False,
+                'MaxItems': '100',
+                'Marker': '',
+            },
+        )
+
+        stubber.add_response(
+            'change_resource_record_sets',
+            {
+                'ChangeInfo': {
+                    'Id': 'id',
+                    'Status': 'PENDING',
+                    'SubmittedAt': '2017-01-29T01:02:03Z',
+                }
+            },
+            {'HostedZoneId': 'z42', 'ChangeBatch': ANY},
+        )
+
+        self.assertEqual(13, provider.apply(plan))
+        stubber.assert_no_pending_responses()
+
+    def test_sync_create_private(self):
+        provider, stubber = self._get_stubbed_private_provider()
+
+        got = Zone('unit.tests.', [])
+
+        list_hosted_zones_resp = {
+            'HostedZones': [],
+            'Marker': 'm',
+            'IsTruncated': False,
+            'MaxItems': '100',
+        }
+        stubber.add_response('list_hosted_zones', list_hosted_zones_resp, {})
+
+        plan = provider.plan(self.expected)
+        self.assertEqual(13, len(plan.changes))
+        self.assertFalse(plan.exists)
+        for change in plan.changes:
+            self.assertIsInstance(change, Create)
+        stubber.assert_no_pending_responses()
+
+        create_hosted_zone_resp = {
+            'HostedZone': {
+                'Name': 'unit.tests.',
+                'Id': 'z42',
+                'CallerReference': 'abc',
+                'Config': {'PrivateZone': True},
+            },
+            'ChangeInfo': {
+                'Id': 'a12',
+                'Status': 'PENDING',
+                'SubmittedAt': '2017-01-29T01:02:03Z',
+                'Comment': 'hrm',
+            },
+            'DelegationSet': {
+                'Id': 'b23',
+                'CallerReference': 'blip',
+                'NameServers': ['n12.unit.tests.'],
+            },
+            'Location': 'us-east-1',
+        }
+        stubber.add_response(
+            'create_hosted_zone',
+            create_hosted_zone_resp,
+            {
+                'Name': got.name,
+                'CallerReference': ANY,
+                'HostedZoneConfig': {'PrivateZone': True},
             },
         )
 

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -639,6 +639,22 @@ class TestRoute53Provider(TestCase):
 
         return (provider, stubber)
 
+    def _get_stubbed_get_zones_by_name_enabled_private_provider(self):
+        provider = Route53Provider(
+            'test',
+            'abc',
+            '123',
+            get_zones_by_name=True,
+            strict_supports=False,
+            private=True,
+        )
+
+        # Use the stubber
+        stubber = Stubber(provider._conn)
+        stubber.activate()
+
+        return (provider, stubber)
+
     def test_update_r53_zones(self):
         provider, stubber = self._get_stubbed_provider()
 
@@ -692,6 +708,42 @@ class TestRoute53Provider(TestCase):
         provider.update_r53_zones("unit.tests.")
         self.assertEqual(provider._r53_zones, {'private.unit.tests.': 'z41'})
 
+    def test_get_r53_private_zones_with_get_zones_by_name(self):
+        (provider, stubber) = (
+            self._get_stubbed_get_zones_by_name_enabled_private_provider()
+        )
+
+        list_hosted_zones_by_name_resp = {
+            'HostedZones': [
+                {
+                    'Id': 'z40',
+                    'Name': 'unit.tests.',
+                    'CallerReference': 'abc',
+                    'Config': {'Comment': 'string', 'PrivateZone': False},
+                    'ResourceRecordSetCount': 123,
+                },
+                {
+                    'Id': 'z41',
+                    'Name': 'unit.tests.',
+                    'CallerReference': 'abc',
+                    'Config': {'Comment': 'string', 'PrivateZone': True},
+                    'ResourceRecordSetCount': 123,
+                },
+            ],
+            'DNSName': 'unit.tests.',
+            'IsTruncated': False,
+            'MaxItems': '100',
+        }
+
+        stubber.add_response(
+            'list_hosted_zones_by_name',
+            list_hosted_zones_by_name_resp,
+            {'DNSName': 'unit.tests.', 'MaxItems': '100'},
+        )
+
+        provider.update_r53_zones("unit.tests.")
+        self.assertEqual(provider._r53_zones, {'unit.tests.': 'z41'})
+
     def test_update_r53_zones_with_get_zones_by_name(self):
         (provider, stubber) = (
             self._get_stubbed_get_zones_by_name_enabled_provider()
@@ -709,13 +761,13 @@ class TestRoute53Provider(TestCase):
             ],
             'DNSName': 'unit.tests.',
             'IsTruncated': False,
-            'MaxItems': '1',
+            'MaxItems': '100',
         }
 
         stubber.add_response(
             'list_hosted_zones_by_name',
             list_hosted_zones_by_name_resp,
-            {'DNSName': 'unit.tests.', 'MaxItems': '1'},
+            {'DNSName': 'unit.tests.', 'MaxItems': '100'},
         )
 
         provider.update_r53_zones("unit.tests.")
@@ -763,13 +815,13 @@ class TestRoute53Provider(TestCase):
             ],
             'DNSName': '0/25.2.0.192.in-addr.arpa.',
             'IsTruncated': False,
-            'MaxItems': '1',
+            'MaxItems': '100',
         }
 
         stubber.add_response(
             'list_hosted_zones_by_name',
             list_hosted_zones_by_name_resp,
-            {'DNSName': '0/25.2.0.192.in-addr.arpa.', 'MaxItems': '1'},
+            {'DNSName': '0/25.2.0.192.in-addr.arpa.', 'MaxItems': '100'},
         )
 
         provider.update_r53_zones("0/25.2.0.192.in-addr.arpa.")
@@ -2568,7 +2620,7 @@ class TestRoute53Provider(TestCase):
         stubber.add_response(
             'list_hosted_zones_by_name',
             list_hosted_zones_by_name_resp_1,
-            {'DNSName': 'unit.tests.', 'MaxItems': '1'},
+            {'DNSName': 'unit.tests.', 'MaxItems': '100'},
         )
 
         # empty is empty
@@ -2580,7 +2632,7 @@ class TestRoute53Provider(TestCase):
         stubber.add_response(
             'list_hosted_zones_by_name',
             list_hosted_zones_by_name_resp_2,
-            {'DNSName': 'unit2.tests.', 'MaxItems': '1'},
+            {'DNSName': 'unit2.tests.', 'MaxItems': '100'},
         )
 
         # empty is empty
@@ -2613,7 +2665,7 @@ class TestRoute53Provider(TestCase):
         stubber.add_response(
             'list_hosted_zones_by_name',
             list_hosted_zones_by_name_resp,
-            {'DNSName': 'unit.tests.', 'MaxItems': '1'},
+            {'DNSName': 'unit.tests.', 'MaxItems': '100'},
         )
 
         # empty is empty
@@ -2640,7 +2692,7 @@ class TestRoute53Provider(TestCase):
         stubber.add_response(
             'list_hosted_zones_by_name',
             list_hosted_zones_by_name_resp,
-            {'DNSName': 'unit.tests.', 'MaxItems': '1'},
+            {'DNSName': 'unit.tests.', 'MaxItems': '100'},
         )
 
         plan = provider.plan(self.expected)
@@ -2752,7 +2804,7 @@ class TestRoute53Provider(TestCase):
         stubber.add_response(
             'list_hosted_zones_by_name',
             list_hosted_zones_by_name_resp,
-            {'DNSName': 'unit.tests.', 'MaxItems': '1'},
+            {'DNSName': 'unit.tests.', 'MaxItems': '100'},
         )
 
         stubber.add_response(


### PR DESCRIPTION
AWS Route53 can host both internal and external zones with the same names (Split-view DNS - https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns). Depending on the order of records returned by `list_hosted_zones` when searching by name, the wrong zone might be selected.

This PR adds support for specifying a `private` flag in the provider settings.
- If the flag is not set, the provider’s behavior remains unchanged.
- If set to `False`, the provider will search for only public zones.
- If set to `True`, it will search for only private zones.

Also, when `private: True` is specified, the provider will mark the zone as private during creation.