### PR TITLE
Add subnet/CIDR-based routing support

### DIFF
--- a/.changelog/929515fc7a0a4fa995854a26fb145051.md
+++ b/.changelog/929515fc7a0a4fa995854a26fb145051.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add subnet/CIDR-based routing support

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -2176,6 +2176,21 @@ class Route53Provider(_AuthMixin, BaseProvider):
             collection_id = self._get_or_create_cidr_collection(desired.name)
             self._sync_cidr_locations(collection_id, desired_locations)
 
+        if collection_id is None:
+            # Check if any existing records being deleted/updated use
+            # subnets, we'll need the collection_id to match the rrsets
+            for c in changes:
+                existing = getattr(c, 'existing', None)
+                if existing and getattr(existing, 'dynamic', False):
+                    for rule in existing.dynamic.rules:
+                        if rule.data.get('subnets', []):
+                            collection_id = self._get_cidr_collection(
+                                desired.name
+                            )
+                            break
+                    if collection_id is not None:
+                        break
+
         batch = []
         batch_rs_count = 0
         zone_id = self._get_zone_id(desired.name, True)

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -2174,7 +2174,6 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     desired_locations[f'r{i}'] = sorted(subnets)
         if desired_locations:
             collection_id = self._get_or_create_cidr_collection(desired.name)
-            self._sync_cidr_locations(collection_id, desired_locations)
 
         if collection_id is None:
             # Check if any existing records being deleted/updated use
@@ -2190,6 +2189,11 @@ class Route53Provider(_AuthMixin, BaseProvider):
                             break
                     if collection_id is not None:
                         break
+
+        if collection_id is not None:
+            self._sync_cidr_locations(collection_id, desired_locations)
+            if not desired_locations:
+                self._conn.delete_cidr_collection(Id=collection_id)
 
         batch = []
         batch_rs_count = 0

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -833,7 +833,6 @@ class Route53Provider(_AuthMixin, BaseProvider):
         self._vpc_zone_ids = None  # Cache of zone IDs associated with vpc_id
         self._multi_vpc_zones = None  # Cache: {zone_id: [vpc_ids]}
         self._cidr_collections = {}  # Cache: collection_id -> {loc: [cidrs]}
-        self._current_cidr_collection_id = None
 
     def _get_zone_id_by_name(self, name):
         # attempt to get zone by name
@@ -1840,30 +1839,36 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     )
                     self._conn.delete_health_check(HealthCheckId=id)
 
-    def _gen_records(self, record, zone_id, creating=False):
+    def _gen_records(self, record, zone_id, creating=False, collection_id=None):
         '''
         Turns an octodns.Record into one or more `_Route53*`s
         '''
-        collection_id = getattr(self, '_current_cidr_collection_id', None)
         return _Route53Record.new(
             self, record, zone_id, creating, collection_id=collection_id
         )
 
-    def _mod_Create(self, change, zone_id, existing_rrsets):
+    def _mod_Create(self, change, zone_id, existing_rrsets, collection_id=None):
         # New is the stuff that needs to be created
-        new_records = self._gen_records(change.new, zone_id, creating=True)
+        new_records = self._gen_records(
+            change.new, zone_id, creating=True, collection_id=collection_id
+        )
         # Now is a good time to clear out any unused health checks since we
         # know what we'll be using going forward
         self._gc_health_checks(change.new, new_records)
         return self._gen_mods('CREATE', new_records, existing_rrsets)
 
-    def _mod_Update(self, change, zone_id, existing_rrsets):
+    def _mod_Update(self, change, zone_id, existing_rrsets, collection_id=None):
         # See comments in _Route53Record for how the set math is made to do our
         # bidding here.
         existing_records = self._gen_records(
-            change.existing, zone_id, creating=False
+            change.existing,
+            zone_id,
+            creating=False,
+            collection_id=collection_id,
         )
-        new_records = self._gen_records(change.new, zone_id, creating=True)
+        new_records = self._gen_records(
+            change.new, zone_id, creating=True, collection_id=collection_id
+        )
         # Now is a good time to clear out any unused health checks since we
         # know what we'll be using going forward
         self._gc_health_checks(change.new, new_records)
@@ -1887,10 +1892,13 @@ class Route53Provider(_AuthMixin, BaseProvider):
             + self._gen_mods('UPSERT', upserts, existing_rrsets)
         )
 
-    def _mod_Delete(self, change, zone_id, existing_rrsets):
+    def _mod_Delete(self, change, zone_id, existing_rrsets, collection_id=None):
         # Existing is the thing that needs to be deleted
         existing_records = self._gen_records(
-            change.existing, zone_id, creating=False
+            change.existing,
+            zone_id,
+            creating=False,
+            collection_id=collection_id,
         )
         # Now is a good time to clear out all the health checks since we know
         # we're done with them
@@ -2099,7 +2107,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
                         )
 
         # Ensure CIDR collection exists if any desired records use subnets
-        self._current_cidr_collection_id = None
+        collection_id = None
         desired_locations = {}
         for record in desired.records:
             if not getattr(record, 'dynamic', False):
@@ -2111,7 +2119,6 @@ class Route53Provider(_AuthMixin, BaseProvider):
         if desired_locations:
             collection_id = self._get_or_create_cidr_collection(desired.name)
             self._sync_cidr_locations(collection_id, desired_locations)
-            self._current_cidr_collection_id = collection_id
 
         batch = []
         batch_rs_count = 0
@@ -2127,7 +2134,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     c = Update(new, new)
             klass = c.__class__.__name__
             mod_type = getattr(self, f'_mod_{klass}')
-            mods = mod_type(c, zone_id, existing_rrsets)
+            mods = mod_type(c, zone_id, existing_rrsets, collection_id)
 
             # Order our mods to make sure targets exist before alises point to
             # them and we CRUD in the desired order

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -204,9 +204,8 @@ class _Route53Record(EqualityTupleMixin):
                     )
                 )
             else:
-                # There's no geo's for this rule so it's the catchall that will
-                # just point things that don't match any geo rules to the
-                # specified pool
+                # Catchall for geo records that will just point things that
+                # don't match any geo rules to the specified pool
                 ret.add(
                     _Route53DynamicRule(
                         provider, hosted_zone_id, record, pool_name, i, creating
@@ -1274,27 +1273,18 @@ class Route53Provider(_AuthMixin, BaseProvider):
         for loc_name, cidrs in desired_locations.items():
             desired_set = set(cidrs)
             existing_set = set(existing.get(loc_name, []))
-            if desired_set != existing_set:
-                # DELETE blocks that are no longer wanted
-                to_remove = sorted(existing_set - desired_set)
-                if to_remove:
-                    changes.append(
-                        {
-                            'LocationName': loc_name,
-                            'Action': 'DELETE_IF_EXISTS',
-                            'CidrList': to_remove,
-                        }
-                    )
-                # PUT blocks that need to be added
-                to_add = sorted(desired_set - existing_set)
-                if to_add:
-                    changes.append(
-                        {
-                            'LocationName': loc_name,
-                            'Action': 'PUT',
-                            'CidrList': to_add,
-                        }
-                    )
+            # we don't/can't delete CIRD locations since they may be in use by
+            # other records or zones
+            to_add = sorted(desired_set - existing_set)
+            # PUT blocks that need to be added
+            if to_add:
+                changes.append(
+                    {
+                        'LocationName': loc_name,
+                        'Action': 'PUT',
+                        'CidrList': to_add,
+                    }
+                )
 
         if changes:
             self._conn.change_cidr_collection(Id=collection_id, Changes=changes)

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -64,7 +64,9 @@ class _Route53Record(EqualityTupleMixin):
         )
 
     @classmethod
-    def _new_dynamic(cls, provider, record, hosted_zone_id, creating):
+    def _new_dynamic(
+        cls, provider, record, hosted_zone_id, creating, collection_id=None
+    ):
         # Creates the RRSets that correspond to the given dynamic record
         ret = set()
 
@@ -150,7 +152,21 @@ class _Route53Record(EqualityTupleMixin):
         for i, rule in enumerate(record.dynamic.rules):
             pool_name = rule.data['pool']
             geos = rule.data.get('geos', [])
-            if geos:
+            subnets = rule.data.get('subnets', [])
+            if subnets:
+                # Create a CidrRoutingConfig RRSet for subnet-based routing
+                ret.add(
+                    _Route53DynamicSubnetRule(
+                        provider,
+                        hosted_zone_id,
+                        record,
+                        pool_name,
+                        i,
+                        creating,
+                        collection_id,
+                    )
+                )
+            elif geos:
                 for geo in geos:
                     # Create a RRSet for each geo in each rule that uses the
                     # desired target pool
@@ -167,8 +183,8 @@ class _Route53Record(EqualityTupleMixin):
                     )
             else:
                 # There's no geo's for this rule so it's the catchall that will
-                # just point things that don't match any geo rules to the
-                # specified pool
+                # just point things that don't match any geo or subnet rules to
+                # the specified pool
                 ret.add(
                     _Route53DynamicRule(
                         provider, hosted_zone_id, record, pool_name, i, creating
@@ -178,11 +194,19 @@ class _Route53Record(EqualityTupleMixin):
         return ret
 
     @classmethod
-    def new(cls, provider, record, hosted_zone_id, creating):
+    def new(
+        cls, provider, record, hosted_zone_id, creating, collection_id=None
+    ):
         # Creates the RRSets that correspond to the given record
 
         if getattr(record, 'dynamic', False):
-            ret = cls._new_dynamic(provider, record, hosted_zone_id, creating)
+            ret = cls._new_dynamic(
+                provider,
+                record,
+                hosted_zone_id,
+                creating,
+                collection_id=collection_id,
+            )
             return ret
         elif record._type == Route53AliasRecord._type:
             return cls._new_route53_alias(
@@ -469,6 +493,59 @@ class _Route53DynamicRule(_Route53Record):
         return f'_Route53DynamicRule<{self.fqdn} {self._type} {self.index} {self.geo} {self.target_dns_name}>'
 
 
+class _Route53DynamicSubnetRule(_Route53Record):
+    def __init__(
+        self,
+        provider,
+        hosted_zone_id,
+        record,
+        pool_name,
+        index,
+        creating,
+        collection_id,
+    ):
+        super().__init__(provider, record, creating)
+
+        self.hosted_zone_id = hosted_zone_id
+        self.pool_name = pool_name
+        self.index = index
+        self.collection_id = collection_id
+
+        self.target_dns_name = f'_octodns-{pool_name}-pool.{record.fqdn}'
+
+    @property
+    def identifer(self):
+        return f'{self.index}-{self.pool_name}-subnet'
+
+    def mod(self, action, existing_rrsets):
+        return {
+            'Action': action,
+            'ResourceRecordSet': {
+                'AliasTarget': {
+                    'DNSName': self.target_dns_name,
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': self.hosted_zone_id,
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': self.collection_id,
+                    'LocationName': f'r{self.index}',
+                },
+                'Name': self.fqdn,
+                'SetIdentifier': self.identifer,
+                'Type': self._type,
+            },
+        }
+
+    def __hash__(self):
+        return f'{self.fqdn}:{self._type}:{self.identifer}'.__hash__()
+
+    def __repr__(self):
+        return (
+            f'_Route53DynamicSubnetRule<{self.fqdn} {self._type}'
+            f' {self.index} {self.target_dns_name}>'
+        )
+
+
 class _Route53DynamicValue(_Route53Record):
     def __init__(
         self,
@@ -572,7 +649,10 @@ def _mod_keyer(mod):
     # dependency order, we just rely on that.
 
     # Get the unique ID from the name/id to get a consistent ordering.
-    if rrset.get('GeoLocation', False):
+    is_rule = rrset.get('GeoLocation', False) or rrset.get(
+        'CidrRoutingConfig', False
+    )
+    if is_rule:
         unique_id = rrset['SetIdentifier']
     else:
         if 'SetIdentifier' in rrset:
@@ -581,8 +661,8 @@ def _mod_keyer(mod):
             unique_id = rrset['Name']
 
     # Prioritise within the action_priority, ensuring targets come first.
-    if rrset.get('GeoLocation', False):
-        # Geos reference pools, so they come last.
+    if is_rule:
+        # Geos/subnets reference pools, so they come last.
         record_priority = 3
     elif rrset.get('AliasTarget', False):
         # We use an alias
@@ -641,6 +721,7 @@ class Route53Provider(_AuthMixin, BaseProvider):
 
     SUPPORTS_GEO = True
     SUPPORTS_DYNAMIC = True
+    SUPPORTS_DYNAMIC_SUBNETS = True
     SUPPORTS_POOL_VALUE_STATUS = True
     SUPPORTS_ROOT_NS = True
     SUPPORTS = set(
@@ -751,6 +832,8 @@ class Route53Provider(_AuthMixin, BaseProvider):
         self._health_checks = None
         self._vpc_zone_ids = None  # Cache of zone IDs associated with vpc_id
         self._multi_vpc_zones = None  # Cache: {zone_id: [vpc_ids]}
+        self._cidr_collections = {}  # Cache: collection_id -> {loc: [cidrs]}
+        self._current_cidr_collection_id = None
 
     def _get_zone_id_by_name(self, name):
         # attempt to get zone by name
@@ -1105,13 +1188,97 @@ class Route53Provider(_AuthMixin, BaseProvider):
 
         return self._r53_rrsets[zone_id]
 
+    @staticmethod
+    def _cidr_collection_name(zone_name):
+        # Remove trailing dot and replace dots with dashes for a valid name
+        return f'octodns-{zone_name.rstrip(".").replace(".", "-")}'
+
+    def _get_cidr_collection(self, zone_name):
+        name = self._cidr_collection_name(zone_name)
+        more = True
+        params = {}
+        while more:
+            resp = self._conn.list_cidr_collections(**params)
+            for collection in resp['CidrCollections']:
+                if collection['Name'] == name:
+                    return collection['Id']
+            more = 'NextToken' in resp
+            if more:
+                params['NextToken'] = resp['NextToken']
+        return None
+
+    def _create_cidr_collection(self, zone_name):
+        name = self._cidr_collection_name(zone_name)
+        resp = self._conn.create_cidr_collection(
+            Name=name, CallerReference=uuid4().hex
+        )
+        return resp['Collection']['Id']
+
+    def _get_or_create_cidr_collection(self, zone_name):
+        collection_id = self._get_cidr_collection(zone_name)
+        if collection_id is None:
+            collection_id = self._create_cidr_collection(zone_name)
+        return collection_id
+
+    def _load_cidr_blocks(self, collection_id):
+        if collection_id in self._cidr_collections:
+            return self._cidr_collections[collection_id]
+
+        blocks = defaultdict(list)
+        more = True
+        params = {'CollectionId': collection_id}
+        while more:
+            resp = self._conn.list_cidr_blocks(**params)
+            for item in resp['CidrBlocks']:
+                blocks[item['LocationName']].append(item['CidrBlock'])
+            more = 'NextToken' in resp
+            if more:
+                params['NextToken'] = resp['NextToken']
+
+        result = dict(blocks)
+        self._cidr_collections[collection_id] = result
+        return result
+
+    def _sync_cidr_locations(self, collection_id, desired_locations):
+        existing = self._load_cidr_blocks(collection_id)
+        changes = []
+
+        # Add/update desired locations
+        for loc_name, cidrs in desired_locations.items():
+            existing_cidrs = sorted(existing.get(loc_name, []))
+            if sorted(cidrs) != existing_cidrs:
+                # PUT replaces the location's blocks
+                changes.append(
+                    {
+                        'LocationName': loc_name,
+                        'Action': 'PUT',
+                        'CidrList': sorted(cidrs),
+                    }
+                )
+
+        # Remove locations that are no longer needed
+        for loc_name in existing:
+            if loc_name not in desired_locations:
+                changes.append(
+                    {
+                        'LocationName': loc_name,
+                        'Action': 'DELETE_IF_EXISTS',
+                        'CidrList': sorted(existing[loc_name]),
+                    }
+                )
+
+        if changes:
+            self._conn.change_cidr_collection(Id=collection_id, Changes=changes)
+            # Invalidate cache
+            self._cidr_collections.pop(collection_id, None)
+
     def _data_for_dynamic(self, name, _type, rrsets):
         # This converts a bunch of RRSets into their corresponding dynamic
         # Record. It's used by populate.
         pools = defaultdict(lambda: {'values': []})
         # Data to build our rules will be collected here and "converted" into
         # their final form below
-        rules = defaultdict(lambda: {'pool': None, 'geos': []})
+        rules = defaultdict(lambda: {'pool': None, 'geos': [], 'subnets': []})
         # Base/empty data
         data = {'dynamic': {'pools': pools, 'rules': []}}
 
@@ -1136,6 +1303,16 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     # we'll record
                     if fallback_name != 'default':
                         pools[pool_name]['fallback'] = fallback_name
+            elif 'CidrRoutingConfig' in rrset:
+                # These are subnet rules
+                _id = rrset['SetIdentifier']
+                i = int(_id.split('-', 1)[0])
+                target_pool = _parse_pool_name(rrset['AliasTarget']['DNSName'])
+                rules[i]['pool'] = target_pool
+                collection_id = rrset['CidrRoutingConfig']['CollectionId']
+                location_name = rrset['CidrRoutingConfig']['LocationName']
+                cidr_blocks = self._load_cidr_blocks(collection_id)
+                rules[i]['subnets'] = sorted(cidr_blocks.get(location_name, []))
             elif 'GeoLocation' in rrset:
                 # These are rules
                 _id = rrset['SetIdentifier']
@@ -1184,6 +1361,9 @@ class Route53Provider(_AuthMixin, BaseProvider):
         # the data
         for _, rule in sorted(rules.items()):
             r = {'pool': rule['pool']}
+            subnets = sorted(rule.get('subnets', []))
+            if subnets:
+                r['subnets'] = subnets
             geos = sorted(rule['geos'])
             if geos:
                 r['geos'] = geos
@@ -1664,7 +1844,10 @@ class Route53Provider(_AuthMixin, BaseProvider):
         '''
         Turns an octodns.Record into one or more `_Route53*`s
         '''
-        return _Route53Record.new(self, record, zone_id, creating)
+        collection_id = getattr(self, '_current_cidr_collection_id', None)
+        return _Route53Record.new(
+            self, record, zone_id, creating, collection_id=collection_id
+        )
 
     def _mod_Create(self, change, zone_id, existing_rrsets):
         # New is the stuff that needs to be created
@@ -1786,6 +1969,37 @@ class Route53Provider(_AuthMixin, BaseProvider):
         fqdn = record.fqdn
         _type = record._type
 
+        # Check for CIDR location drift
+        for rrset in self._load_records(zone_id):
+            if 'CidrRoutingConfig' in rrset and rrset.get(
+                'AliasTarget', {}
+            ).get('DNSName', '').startswith('_octodns-'):
+                # Found an existing CIDR rule, check if it belongs to this
+                # record by seeing if the alias target ends with our fqdn
+                target = rrset['AliasTarget']['DNSName']
+                if not target.endswith(f'.{fqdn}'):
+                    continue
+                if _type != rrset['Type']:
+                    continue
+                collection_id = rrset['CidrRoutingConfig']['CollectionId']
+                location_name = rrset['CidrRoutingConfig']['LocationName']
+                cidr_blocks = self._load_cidr_blocks(collection_id)
+                existing_cidrs = sorted(cidr_blocks.get(location_name, []))
+                # Find the matching rule by index from SetIdentifier
+                _id = rrset['SetIdentifier']
+                i = int(_id.split('-', 1)[0])
+                rules = record.dynamic.rules
+                if i < len(rules):
+                    desired_cidrs = sorted(rules[i].data.get('subnets', []))
+                    if existing_cidrs != desired_cidrs:
+                        self.log.info(
+                            '_extra_changes_dynamic_needs_update: '
+                            'cidr-location caused update of %s:%s',
+                            record.fqdn,
+                            record._type,
+                        )
+                        return True
+
         # map values to statuses
         statuses = {}
         for pool in record.dynamic.pools.values():
@@ -1883,6 +2097,21 @@ class Route53Provider(_AuthMixin, BaseProvider):
                             len(vpc_list),
                             vpc_ids_str,
                         )
+
+        # Ensure CIDR collection exists if any desired records use subnets
+        self._current_cidr_collection_id = None
+        desired_locations = {}
+        for record in desired.records:
+            if not getattr(record, 'dynamic', False):
+                continue
+            for i, rule in enumerate(record.dynamic.rules):
+                subnets = rule.data.get('subnets', [])
+                if subnets:
+                    desired_locations[f'r{i}'] = sorted(subnets)
+        if desired_locations:
+            collection_id = self._get_or_create_cidr_collection(desired.name)
+            self._sync_cidr_locations(collection_id, desired_locations)
+            self._current_cidr_collection_id = collection_id
 
         batch = []
         batch_rs_count = 0

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -149,6 +149,10 @@ class _Route53Record(EqualityTupleMixin):
                 )
 
         # Rules
+        # Check if any rule uses subnets to determine catchall type
+        has_subnets = any(
+            rule.data.get('subnets', []) for rule in record.dynamic.rules
+        )
         for i, rule in enumerate(record.dynamic.rules):
             pool_name = rule.data['pool']
             geos = rule.data.get('geos', [])
@@ -181,10 +185,25 @@ class _Route53Record(EqualityTupleMixin):
                             geo=geo,
                         )
                     )
+            elif has_subnets:
+                # Catchall for subnet-based routing uses CidrRoutingConfig
+                # with the special '*' LocationName as the default
+                ret.add(
+                    _Route53DynamicSubnetRule(
+                        provider,
+                        hosted_zone_id,
+                        record,
+                        pool_name,
+                        i,
+                        creating,
+                        collection_id,
+                        default=True,
+                    )
+                )
             else:
                 # There's no geo's for this rule so it's the catchall that will
-                # just point things that don't match any geo or subnet rules to
-                # the specified pool
+                # just point things that don't match any geo rules to the
+                # specified pool
                 ret.add(
                     _Route53DynamicRule(
                         provider, hosted_zone_id, record, pool_name, i, creating
@@ -503,6 +522,7 @@ class _Route53DynamicSubnetRule(_Route53Record):
         index,
         creating,
         collection_id,
+        default=False,
     ):
         super().__init__(provider, record, creating)
 
@@ -510,6 +530,7 @@ class _Route53DynamicSubnetRule(_Route53Record):
         self.pool_name = pool_name
         self.index = index
         self.collection_id = collection_id
+        self.default = default
 
         self.target_dns_name = f'_octodns-{pool_name}-pool.{record.fqdn}'
 
@@ -528,7 +549,7 @@ class _Route53DynamicSubnetRule(_Route53Record):
                 },
                 'CidrRoutingConfig': {
                     'CollectionId': self.collection_id,
-                    'LocationName': f'r{self.index}',
+                    'LocationName': '*' if self.default else f'r{self.index}',
                 },
                 'Name': self.fqdn,
                 'SetIdentifier': self.identifer,
@@ -1244,16 +1265,29 @@ class Route53Provider(_AuthMixin, BaseProvider):
 
         # Add/update desired locations
         for loc_name, cidrs in desired_locations.items():
-            existing_cidrs = sorted(existing.get(loc_name, []))
-            if sorted(cidrs) != existing_cidrs:
-                # PUT replaces the location's blocks
-                changes.append(
-                    {
-                        'LocationName': loc_name,
-                        'Action': 'PUT',
-                        'CidrList': sorted(cidrs),
-                    }
-                )
+            desired_set = set(cidrs)
+            existing_set = set(existing.get(loc_name, []))
+            if desired_set != existing_set:
+                # DELETE blocks that are no longer wanted
+                to_remove = sorted(existing_set - desired_set)
+                if to_remove:
+                    changes.append(
+                        {
+                            'LocationName': loc_name,
+                            'Action': 'DELETE_IF_EXISTS',
+                            'CidrList': to_remove,
+                        }
+                    )
+                # PUT blocks that need to be added
+                to_add = sorted(desired_set - existing_set)
+                if to_add:
+                    changes.append(
+                        {
+                            'LocationName': loc_name,
+                            'Action': 'PUT',
+                            'CidrList': to_add,
+                        }
+                    )
 
         # Remove locations that are no longer needed
         for loc_name in existing:
@@ -1308,10 +1342,14 @@ class Route53Provider(_AuthMixin, BaseProvider):
                 i = int(_id.split('-', 1)[0])
                 target_pool = _parse_pool_name(rrset['AliasTarget']['DNSName'])
                 rules[i]['pool'] = target_pool
-                collection_id = rrset['CidrRoutingConfig']['CollectionId']
                 location_name = rrset['CidrRoutingConfig']['LocationName']
-                cidr_blocks = self._load_cidr_blocks(collection_id)
-                rules[i]['subnets'] = sorted(cidr_blocks.get(location_name, []))
+                if location_name != '*':
+                    # Non-default rules have actual CIDR blocks
+                    collection_id = rrset['CidrRoutingConfig']['CollectionId']
+                    cidr_blocks = self._load_cidr_blocks(collection_id)
+                    rules[i]['subnets'] = sorted(
+                        cidr_blocks.get(location_name, [])
+                    )
             elif 'GeoLocation' in rrset:
                 # These are rules
                 _id = rrset['SetIdentifier']
@@ -1989,8 +2027,11 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     continue
                 if _type != rrset['Type']:
                     continue
-                collection_id = rrset['CidrRoutingConfig']['CollectionId']
                 location_name = rrset['CidrRoutingConfig']['LocationName']
+                if location_name == '*':
+                    # Default/catchall rule, no CIDR blocks to check
+                    continue
+                collection_id = rrset['CidrRoutingConfig']['CollectionId']
                 cidr_blocks = self._load_cidr_blocks(collection_id)
                 existing_cidrs = sorted(cidr_blocks.get(location_name, []))
                 # Find the matching rule by index from SetIdentifier

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1431,13 +1431,8 @@ class Route53Provider(_AuthMixin, BaseProvider):
                 # Make a copy of the record in case we have to muck with it
                 dynamic = record.dynamic
 
-                has_geos = False
-                has_subnets = False
-                for rule in dynamic.rules:
-                    if rule.data.get('geos', []):
-                        has_geos = True
-                    if rule.data.get('subnets', []):
-                        has_subnets = True
+                has_geos = any(r.data.get('geos') for r in dynamic.rules)
+                has_subnets = any(r.data.get('subnets') for r in dynamic.rules)
                 if has_geos and has_subnets:
                     msg = (
                         f'mixed geo and subnet rules not supported '

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1444,6 +1444,21 @@ class Route53Provider(_AuthMixin, BaseProvider):
 
                 # Make a copy of the record in case we have to muck with it
                 dynamic = record.dynamic
+
+                has_geos = False
+                has_subnets = False
+                for rule in dynamic.rules:
+                    if rule.data.get('geos', []):
+                        has_geos = True
+                    if rule.data.get('subnets', []):
+                        has_subnets = True
+                if has_geos and has_subnets:
+                    msg = (
+                        f'mixed geo and subnet rules not supported '
+                        f'for {record.fqdn}'
+                    )
+                    raise SupportsException(f'{self.id}: {msg}')
+
                 rules = []
                 for i, rule in enumerate(dynamic.rules):
                     geos = rule.data.get('geos', [])

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import re
 from collections import defaultdict
+from hashlib import sha256
 from ipaddress import AddressValueError, ip_address
 from uuid import uuid4
 
@@ -159,6 +160,7 @@ class _Route53Record(EqualityTupleMixin):
             subnets = rule.data.get('subnets', [])
             if subnets:
                 # Create a CidrRoutingConfig RRSet for subnet-based routing
+                location_name = Route53Provider._cidr_location_name(subnets)
                 ret.add(
                     _Route53DynamicSubnetRule(
                         provider,
@@ -168,6 +170,7 @@ class _Route53Record(EqualityTupleMixin):
                         i,
                         creating,
                         collection_id,
+                        location_name=location_name,
                     )
                 )
             elif geos:
@@ -523,6 +526,7 @@ class _Route53DynamicSubnetRule(_Route53Record):
         creating,
         collection_id,
         default=False,
+        location_name=None,
     ):
         super().__init__(provider, record, creating)
 
@@ -531,6 +535,7 @@ class _Route53DynamicSubnetRule(_Route53Record):
         self.index = index
         self.collection_id = collection_id
         self.default = default
+        self.location_name = location_name
 
         self.target_dns_name = f'_octodns-{pool_name}-pool.{record.fqdn}'
 
@@ -549,7 +554,7 @@ class _Route53DynamicSubnetRule(_Route53Record):
                 },
                 'CidrRoutingConfig': {
                     'CollectionId': self.collection_id,
-                    'LocationName': '*' if self.default else f'r{self.index}',
+                    'LocationName': '*' if self.default else self.location_name,
                 },
                 'Name': self.fqdn,
                 'SetIdentifier': self.identifer,
@@ -1208,13 +1213,15 @@ class Route53Provider(_AuthMixin, BaseProvider):
 
         return self._r53_rrsets[zone_id]
 
-    @staticmethod
-    def _cidr_collection_name(zone_name):
-        # Remove trailing dot and replace dots with dashes for a valid name
-        return f'octodns-{zone_name.rstrip(".").replace(".", "-")}'
+    _CIDR_COLLECTION_NAME = 'octodns'
 
-    def _get_cidr_collection(self, zone_name):
-        name = self._cidr_collection_name(zone_name)
+    @staticmethod
+    def _cidr_location_name(cidrs):
+        key = ','.join(sorted(cidrs))
+        return sha256(key.encode()).hexdigest()[:16]
+
+    def _get_cidr_collection(self):
+        name = self._CIDR_COLLECTION_NAME
         more = True
         params = {}
         while more:
@@ -1227,17 +1234,17 @@ class Route53Provider(_AuthMixin, BaseProvider):
                 params['NextToken'] = resp['NextToken']
         return None
 
-    def _create_cidr_collection(self, zone_name):
-        name = self._cidr_collection_name(zone_name)
+    def _create_cidr_collection(self):
+        name = self._CIDR_COLLECTION_NAME
         resp = self._conn.create_cidr_collection(
             Name=name, CallerReference=uuid4().hex
         )
         return resp['Collection']['Id']
 
-    def _get_or_create_cidr_collection(self, zone_name):
-        collection_id = self._get_cidr_collection(zone_name)
+    def _get_or_create_cidr_collection(self):
+        collection_id = self._get_cidr_collection()
         if collection_id is None:
-            collection_id = self._create_cidr_collection(zone_name)
+            collection_id = self._create_cidr_collection()
         return collection_id
 
     def _load_cidr_blocks(self, collection_id):
@@ -1288,17 +1295,6 @@ class Route53Provider(_AuthMixin, BaseProvider):
                             'CidrList': to_add,
                         }
                     )
-
-        # Remove locations that are no longer needed
-        for loc_name in existing:
-            if loc_name not in desired_locations:
-                changes.append(
-                    {
-                        'LocationName': loc_name,
-                        'Action': 'DELETE_IF_EXISTS',
-                        'CidrList': sorted(existing[loc_name]),
-                    }
-                )
 
         if changes:
             self._conn.change_cidr_collection(Id=collection_id, Changes=changes)
@@ -2042,20 +2038,18 @@ class Route53Provider(_AuthMixin, BaseProvider):
                     continue
                 if _type != rrset['Type']:
                     continue
-                location_name = rrset['CidrRoutingConfig']['LocationName']
-                if location_name == '*':
+                existing_loc = rrset['CidrRoutingConfig']['LocationName']
+                if existing_loc == '*':
                     # Default/catchall rule, no CIDR blocks to check
                     continue
-                collection_id = rrset['CidrRoutingConfig']['CollectionId']
-                cidr_blocks = self._load_cidr_blocks(collection_id)
-                existing_cidrs = sorted(cidr_blocks.get(location_name, []))
                 # Find the matching rule by index from SetIdentifier
                 _id = rrset['SetIdentifier']
                 i = int(_id.split('-', 1)[0])
                 rules = record.dynamic.rules
                 if i < len(rules):
-                    desired_cidrs = sorted(rules[i].data.get('subnets', []))
-                    if existing_cidrs != desired_cidrs:
+                    desired_cidrs = rules[i].data.get('subnets', [])
+                    desired_loc = self._cidr_location_name(desired_cidrs)
+                    if existing_loc != desired_loc:
                         self.log.info(
                             '_extra_changes_dynamic_needs_update: '
                             'cidr-location caused update of %s:%s',
@@ -2168,12 +2162,13 @@ class Route53Provider(_AuthMixin, BaseProvider):
         for record in desired.records:
             if not getattr(record, 'dynamic', False):
                 continue
-            for i, rule in enumerate(record.dynamic.rules):
+            for rule in record.dynamic.rules:
                 subnets = rule.data.get('subnets', [])
                 if subnets:
-                    desired_locations[f'r{i}'] = sorted(subnets)
+                    loc = self._cidr_location_name(subnets)
+                    desired_locations[loc] = sorted(subnets)
         if desired_locations:
-            collection_id = self._get_or_create_cidr_collection(desired.name)
+            collection_id = self._get_or_create_cidr_collection()
 
         if collection_id is None:
             # Check if any existing records being deleted/updated use
@@ -2183,17 +2178,13 @@ class Route53Provider(_AuthMixin, BaseProvider):
                 if existing and getattr(existing, 'dynamic', False):
                     for rule in existing.dynamic.rules:
                         if rule.data.get('subnets', []):
-                            collection_id = self._get_cidr_collection(
-                                desired.name
-                            )
+                            collection_id = self._get_cidr_collection()
                             break
                     if collection_id is not None:
                         break
 
-        if collection_id is not None:
+        if collection_id is not None and desired_locations:
             self._sync_cidr_locations(collection_id, desired_locations)
-            if not desired_locations:
-                self._conn.delete_cidr_collection(Id=collection_id)
 
         batch = []
         batch_rs_count = 0

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -5468,6 +5468,15 @@ class TestRoute53Provider(TestCase):
                 ]
             },
         )
+        # Stub: list_cidr_blocks (existing locations in collection)
+        stubber.add_response(
+            'list_cidr_blocks',
+            {'CidrBlocks': [{'CidrBlock': '10.0.0.0/8', 'LocationName': 'r0'}]},
+        )
+        # Stub: change_cidr_collection (delete stale location)
+        stubber.add_response('change_cidr_collection', {'Id': 'change-cidr-1'})
+        # Stub: delete_cidr_collection (remove empty collection)
+        stubber.add_response('delete_cidr_collection', {})
         # Stub: load_records (existing rrsets)
         stubber.add_response(
             'list_resource_record_sets',

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -5400,6 +5400,95 @@ class TestRoute53Provider(TestCase):
         provider._apply(plan)
         stubber.assert_no_pending_responses()
 
+    def test_apply_delete_subnet_records(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        provider._health_checks = {}
+        provider.get_health_check_id = lambda r, v, s, c: None
+        provider._r53_zones = {'unit.tests.': '/hostedzone/z42'}
+
+        zone = Zone('unit.tests.', [])
+        subnet_record_data = {
+            'dynamic': {
+                'pools': {
+                    'internal': {
+                        'values': [
+                            {'weight': 1, 'value': '10.0.0.1', 'status': 'up'}
+                        ]
+                    },
+                    'external': {
+                        'values': [
+                            {'weight': 1, 'value': '2.2.2.2', 'status': 'up'}
+                        ]
+                    },
+                },
+                'rules': [
+                    {'pool': 'internal', 'subnets': ['10.0.0.0/8']},
+                    {'pool': 'external'},
+                ],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': ['1.1.2.1'],
+        }
+        existing = Record.new(zone, '', subnet_record_data)
+
+        # Also include a dynamic geo record being deleted to exercise
+        # the branch where existing dynamic rules have no subnets
+        geo_record_data = {
+            'dynamic': {
+                'pools': {
+                    'one': {'values': [{'value': '3.3.3.3'}]},
+                    'two': {'values': [{'value': '4.4.4.4'}]},
+                },
+                'rules': [{'geos': ['EU'], 'pool': 'two'}, {'pool': 'one'}],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': ['3.3.3.3'],
+        }
+        geo_existing = Record.new(zone, 'geo', geo_record_data)
+
+        plan = Mock()
+        # Desired zone has no subnet records
+        plan.desired = Zone('unit.tests.', [])
+        plan.changes = [Delete(geo_existing), Delete(existing)]
+
+        # Stub: list_cidr_collections (lookup existing collection)
+        stubber.add_response(
+            'list_cidr_collections',
+            {
+                'CidrCollections': [
+                    {
+                        'Id': 'col-1234',
+                        'Name': 'octodns-unit-tests',
+                        'Arn': 'arn:aws:route53:::cidrcollection/col-1234',
+                        'Version': 1,
+                    }
+                ]
+            },
+        )
+        # Stub: load_records (existing rrsets)
+        stubber.add_response(
+            'list_resource_record_sets',
+            {'ResourceRecordSets': [], 'IsTruncated': False, 'MaxItems': '100'},
+            {'HostedZoneId': '/hostedzone/z42'},
+        )
+        # Stub: change_resource_record_sets (apply)
+        stubber.add_response(
+            'change_resource_record_sets',
+            {
+                'ChangeInfo': {
+                    'Id': 'change-1',
+                    'Status': 'PENDING',
+                    'SubmittedAt': '2024-01-01T00:00:00Z',
+                }
+            },
+        )
+
+        provider._apply(plan)
+        stubber.assert_no_pending_responses()
+
     def test_mod_Update_set_math(self):
         provider = Route53Provider('test', 'abc', '123')
 

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -1605,6 +1605,37 @@ class TestRoute53Provider(TestCase):
             str(ctx.exception),
         )
 
+        # mixed geo and subnet rules
+        desired = Zone('unit.tests.', [])
+        record = Record.new(
+            desired,
+            'a',
+            {
+                'ttl': 30,
+                'type': 'A',
+                'value': '1.2.3.4',
+                'dynamic': {
+                    'pools': {
+                        'one': {'values': [{'value': '1.2.3.4'}]},
+                        'two': {'values': [{'value': '2.2.3.4'}]},
+                    },
+                    'rules': [
+                        {'subnets': ['10.0.0.0/8'], 'pool': 'one'},
+                        {'geos': ['EU', 'NA-US-OR'], 'pool': 'two'},
+                        {'pool': 'one'},
+                    ],
+                },
+            },
+        )
+        desired.add_record(record)
+        with self.assertRaises(SupportsException) as ctx:
+            provider._process_desired_zone(desired)
+        self.assertEqual(
+            'test: mixed geo and subnet rules not supported '
+            'for a.unit.tests.',
+            str(ctx.exception),
+        )
+
     # with fallback boto makes an unstubbed call to the 169. metadata api, this
     # stubs that bit out
     @patch('botocore.credentials.CredentialResolver.load_credentials')

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -18,6 +18,7 @@ from octodns_route53.provider import (
     _mod_keyer,
     _octal_replace,
     _Route53Alias,
+    _Route53DynamicSubnetRule,
     _Route53DynamicValue,
     _Route53Record,
 )
@@ -325,6 +326,98 @@ dynamic_record_data = {
     'type': 'A',
     'values': ['1.1.2.1', '1.1.2.2'],
 }
+
+
+dynamic_subnet_rrsets = [
+    {
+        'Name': '_octodns-default-pool.unit.tests.',
+        'ResourceRecords': [{'Value': '1.1.2.1'}, {'Value': '1.1.2.2'}],
+        'TTL': 60,
+        'Type': 'A',
+    },
+    {
+        'Name': '_octodns-internal-value.unit.tests.',
+        'ResourceRecords': [{'Value': '10.0.0.1'}],
+        'SetIdentifier': 'internal-000',
+        'TTL': 60,
+        'Type': 'A',
+        'Weight': 1,
+    },
+    {
+        'Name': '_octodns-external-value.unit.tests.',
+        'ResourceRecords': [{'Value': '2.2.2.2'}],
+        'SetIdentifier': 'external-000',
+        'TTL': 60,
+        'Type': 'A',
+        'Weight': 1,
+    },
+    {
+        'AliasTarget': {
+            'DNSName': '_octodns-default-pool.unit.tests.',
+            'EvaluateTargetHealth': True,
+            'HostedZoneId': 'Z2',
+        },
+        'Failover': 'SECONDARY',
+        'Name': '_octodns-internal-pool.unit.tests.',
+        'SetIdentifier': 'internal-Secondary-default',
+        'Type': 'A',
+    },
+    {
+        'AliasTarget': {
+            'DNSName': '_octodns-internal-value.unit.tests.',
+            'EvaluateTargetHealth': True,
+            'HostedZoneId': 'Z2',
+        },
+        'Failover': 'PRIMARY',
+        'Name': '_octodns-internal-pool.unit.tests.',
+        'SetIdentifier': 'internal-Primary',
+        'Type': 'A',
+    },
+    {
+        'AliasTarget': {
+            'DNSName': '_octodns-default-pool.unit.tests.',
+            'EvaluateTargetHealth': True,
+            'HostedZoneId': 'Z2',
+        },
+        'Failover': 'SECONDARY',
+        'Name': '_octodns-external-pool.unit.tests.',
+        'SetIdentifier': 'external-Secondary-default',
+        'Type': 'A',
+    },
+    {
+        'AliasTarget': {
+            'DNSName': '_octodns-external-value.unit.tests.',
+            'EvaluateTargetHealth': True,
+            'HostedZoneId': 'Z2',
+        },
+        'Failover': 'PRIMARY',
+        'Name': '_octodns-external-pool.unit.tests.',
+        'SetIdentifier': 'external-Primary',
+        'Type': 'A',
+    },
+    {
+        'AliasTarget': {
+            'DNSName': '_octodns-internal-pool.unit.tests.',
+            'EvaluateTargetHealth': True,
+            'HostedZoneId': 'Z2',
+        },
+        'CidrRoutingConfig': {'CollectionId': 'col-1234', 'LocationName': 'r0'},
+        'Name': 'unit.tests.',
+        'SetIdentifier': '0-internal-subnet',
+        'Type': 'A',
+    },
+    {
+        'AliasTarget': {
+            'DNSName': '_octodns-external-pool.unit.tests.',
+            'EvaluateTargetHealth': True,
+            'HostedZoneId': 'Z2',
+        },
+        'GeoLocation': {'CountryCode': '*'},
+        'Name': 'unit.tests.',
+        'SetIdentifier': '1-external-None',
+        'Type': 'A',
+    },
+]
 
 
 class TestRoute53Provider(TestCase):
@@ -1035,6 +1128,7 @@ class TestRoute53Provider(TestCase):
         # Create minimal mock plan with no changes to avoid further processing
         plan = Mock()
         plan.desired.name = 'unit.tests.'
+        plan.desired.records = []
         plan.changes = []
 
         # Mock methods to avoid API calls
@@ -1071,6 +1165,7 @@ class TestRoute53Provider(TestCase):
         # Create minimal mock plan with no changes
         plan = Mock()
         plan.desired.name = 'unit.tests.'
+        plan.desired.records = []
         plan.changes = []
 
         # Mock methods to avoid API calls
@@ -1105,6 +1200,7 @@ class TestRoute53Provider(TestCase):
 
         plan = Mock()
         plan.desired.name = 'unit.tests.'
+        plan.desired.records = []
         plan.changes = []
 
         # Mock methods to avoid API calls
@@ -4507,6 +4603,677 @@ class TestRoute53Provider(TestCase):
             [r.data for r in record.dynamic.rules],
         )
 
+    def test_data_for_dynamic_subnets(self):
+        provider = Route53Provider('test', 'abc', '123')
+        provider._health_checks = {}
+        provider._cidr_collections = {
+            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+        }
+
+        data = provider._data_for_dynamic('', 'A', dynamic_subnet_rrsets)
+        self.assertEqual('A', data['type'])
+        self.assertEqual(60, data['ttl'])
+        self.assertEqual(['1.1.2.1', '1.1.2.2'], data['values'])
+
+        # Check pools
+        self.assertEqual(
+            {'weight': 1, 'value': '10.0.0.1', 'status': 'up'},
+            data['dynamic']['pools']['internal']['values'][0],
+        )
+        self.assertEqual(
+            {'weight': 1, 'value': '2.2.2.2', 'status': 'up'},
+            data['dynamic']['pools']['external']['values'][0],
+        )
+
+        # Check rules
+        rules = data['dynamic']['rules']
+        self.assertEqual(2, len(rules))
+        self.assertEqual(
+            {'pool': 'internal', 'subnets': ['10.0.0.0/8', '172.16.0.0/12']},
+            rules[0],
+        )
+        self.assertEqual({'pool': 'external'}, rules[1])
+
+    @patch('octodns_route53.Route53Provider._get_zone_id')
+    @patch('octodns_route53.Route53Provider._load_records')
+    def test_dynamic_subnet_populate(self, load_records_mock, get_zone_id_mock):
+        provider = Route53Provider('test', 'abc', '123')
+        provider._health_checks = {}
+        provider._cidr_collections = {
+            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+        }
+
+        get_zone_id_mock.side_effect = ['z44']
+        load_records_mock.side_effect = [dynamic_subnet_rrsets]
+
+        got = Zone('unit.tests.', [])
+        provider.populate(got)
+
+        self.assertEqual(1, len(got.records))
+        record = list(got.records)[0]
+        self.assertEqual('', record.name)
+        self.assertEqual('A', record._type)
+        self.assertTrue(record.dynamic)
+
+        # Verify subnet rule
+        rules = [r.data for r in record.dynamic.rules]
+        self.assertEqual(
+            {'pool': 'internal', 'subnets': ['10.0.0.0/8', '172.16.0.0/12']},
+            rules[0],
+        )
+        # Verify default rule
+        self.assertEqual({'pool': 'external'}, rules[1])
+
+    def test_cidr_collection_name(self):
+        self.assertEqual(
+            'octodns-unit-tests',
+            Route53Provider._cidr_collection_name('unit.tests.'),
+        )
+        self.assertEqual(
+            'octodns-sub-unit-tests',
+            Route53Provider._cidr_collection_name('sub.unit.tests.'),
+        )
+
+    def test_get_cidr_collection(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        collection_summary = {
+            'Id': 'col-1234',
+            'Name': 'octodns-unit-tests',
+            'Arn': 'arn:aws:route53:::cidrcollection/col-1234',
+            'Version': 1,
+        }
+
+        # Collection exists
+        stubber.add_response(
+            'list_cidr_collections', {'CidrCollections': [collection_summary]}
+        )
+        result = provider._get_cidr_collection('unit.tests.')
+        self.assertEqual('col-1234', result)
+
+        # Collection doesn't exist
+        stubber.add_response(
+            'list_cidr_collections',
+            {
+                'CidrCollections': [
+                    {
+                        'Id': 'col-other',
+                        'Name': 'other',
+                        'Arn': 'arn:aws:route53:::cidrcollection/col-other',
+                        'Version': 1,
+                    }
+                ]
+            },
+        )
+        result = provider._get_cidr_collection('unit.tests.')
+        self.assertIsNone(result)
+
+        # Paginated response
+        stubber.add_response(
+            'list_cidr_collections',
+            {
+                'CidrCollections': [
+                    {
+                        'Id': 'col-other',
+                        'Name': 'other',
+                        'Arn': 'arn:aws:route53:::cidrcollection/col-other',
+                        'Version': 1,
+                    }
+                ],
+                'NextToken': 'token1',
+            },
+        )
+        stubber.add_response(
+            'list_cidr_collections',
+            {
+                'CidrCollections': [
+                    {
+                        'Id': 'col-found',
+                        'Name': 'octodns-unit-tests',
+                        'Arn': 'arn:aws:route53:::cidrcollection/col-found',
+                        'Version': 1,
+                    }
+                ]
+            },
+        )
+        result = provider._get_cidr_collection('unit.tests.')
+        self.assertEqual('col-found', result)
+
+        stubber.assert_no_pending_responses()
+
+    def test_create_cidr_collection(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        stubber.add_response(
+            'create_cidr_collection',
+            {
+                'Collection': {
+                    'Id': 'col-new',
+                    'Name': 'octodns-unit-tests',
+                    'Arn': 'arn:aws:route53:::cidrcollection/col-new',
+                    'Version': 1,
+                },
+                'Location': 'https://route53.amazonaws.com/cidrcollection/col-new',
+            },
+        )
+        result = provider._create_cidr_collection('unit.tests.')
+        self.assertEqual('col-new', result)
+        stubber.assert_no_pending_responses()
+
+    def test_load_cidr_blocks(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        stubber.add_response(
+            'list_cidr_blocks',
+            {
+                'CidrBlocks': [
+                    {'CidrBlock': '10.0.0.0/8', 'LocationName': 'r0'},
+                    {'CidrBlock': '172.16.0.0/12', 'LocationName': 'r0'},
+                    {'CidrBlock': '192.168.0.0/16', 'LocationName': 'r1'},
+                ]
+            },
+            {'CollectionId': 'col-1234'},
+        )
+
+        result = provider._load_cidr_blocks('col-1234')
+        self.assertEqual(
+            {'r0': ['10.0.0.0/8', '172.16.0.0/12'], 'r1': ['192.168.0.0/16']},
+            result,
+        )
+
+        # Second call should use cache
+        result2 = provider._load_cidr_blocks('col-1234')
+        self.assertEqual(result, result2)
+        stubber.assert_no_pending_responses()
+
+    def test_sync_cidr_locations(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        # Pre-populate cache with existing state
+        provider._cidr_collections = {
+            'col-1234': {'r0': ['10.0.0.0/8'], 'r1': ['192.168.0.0/16']}
+        }
+
+        stubber.add_response(
+            'change_cidr_collection',
+            {'Id': 'change-id-1234'},
+            {
+                'Id': 'col-1234',
+                'Changes': [
+                    {
+                        'LocationName': 'r0',
+                        'Action': 'PUT',
+                        'CidrList': ['10.0.0.0/8', '172.16.0.0/12'],
+                    },
+                    {
+                        'LocationName': 'r1',
+                        'Action': 'DELETE_IF_EXISTS',
+                        'CidrList': ['192.168.0.0/16'],
+                    },
+                ],
+            },
+        )
+
+        desired = {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+        provider._sync_cidr_locations('col-1234', desired)
+
+        # Cache should be invalidated
+        self.assertNotIn('col-1234', provider._cidr_collections)
+        stubber.assert_no_pending_responses()
+
+    def test_sync_cidr_locations_no_changes(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        # Pre-populate cache - already matches desired
+        provider._cidr_collections = {'col-1234': {'r0': ['10.0.0.0/8']}}
+
+        desired = {'r0': ['10.0.0.0/8']}
+        provider._sync_cidr_locations('col-1234', desired)
+
+        # No API call should be made, cache should remain
+        self.assertIn('col-1234', provider._cidr_collections)
+        stubber.assert_no_pending_responses()
+
+    def test_get_or_create_cidr_collection_existing(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        # Collection already exists
+        stubber.add_response(
+            'list_cidr_collections',
+            {
+                'CidrCollections': [
+                    {
+                        'Id': 'col-existing',
+                        'Name': 'octodns-unit-tests',
+                        'Arn': 'arn:aws:route53:::cidrcollection/col-existing',
+                        'Version': 1,
+                    }
+                ]
+            },
+        )
+        result = provider._get_or_create_cidr_collection('unit.tests.')
+        self.assertEqual('col-existing', result)
+        stubber.assert_no_pending_responses()
+
+    def test_get_or_create_cidr_collection_creates(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        # Collection doesn't exist
+        stubber.add_response('list_cidr_collections', {'CidrCollections': []})
+        # So it creates one
+        stubber.add_response(
+            'create_cidr_collection',
+            {
+                'Collection': {
+                    'Id': 'col-new',
+                    'Name': 'octodns-unit-tests',
+                    'Arn': 'arn:aws:route53:::cidrcollection/col-new',
+                    'Version': 1,
+                },
+                'Location': 'https://route53.amazonaws.com/cidrcollection/col-new',
+            },
+        )
+        result = provider._get_or_create_cidr_collection('unit.tests.')
+        self.assertEqual('col-new', result)
+        stubber.assert_no_pending_responses()
+
+    def test_load_cidr_blocks_paginated(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        stubber.add_response(
+            'list_cidr_blocks',
+            {
+                'CidrBlocks': [
+                    {'CidrBlock': '10.0.0.0/8', 'LocationName': 'r0'}
+                ],
+                'NextToken': 'token1',
+            },
+            {'CollectionId': 'col-1234'},
+        )
+        stubber.add_response(
+            'list_cidr_blocks',
+            {
+                'CidrBlocks': [
+                    {'CidrBlock': '172.16.0.0/12', 'LocationName': 'r0'}
+                ]
+            },
+            {'CollectionId': 'col-1234', 'NextToken': 'token1'},
+        )
+
+        result = provider._load_cidr_blocks('col-1234')
+        self.assertEqual({'r0': ['10.0.0.0/8', '172.16.0.0/12']}, result)
+        stubber.assert_no_pending_responses()
+
+    def test_extra_changes_cidr_drift(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        provider._health_checks = {}
+        provider._cidr_collections = {'col-1234': {'r0': ['10.0.0.0/8']}}
+
+        zone = Zone('unit.tests.', [])
+        subnet_record_data = {
+            'dynamic': {
+                'pools': {
+                    'internal': {
+                        'values': [
+                            {'weight': 1, 'value': '10.0.0.1', 'status': 'up'}
+                        ]
+                    },
+                    'external': {
+                        'values': [
+                            {'weight': 1, 'value': '2.2.2.2', 'status': 'up'}
+                        ]
+                    },
+                },
+                'rules': [
+                    {
+                        'pool': 'internal',
+                        'subnets': ['10.0.0.0/8', '172.16.0.0/12'],
+                    },
+                    {'pool': 'external'},
+                ],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': ['1.1.2.1', '1.1.2.2'],
+        }
+        record = Record.new(zone, '', subnet_record_data)
+
+        # RRsets that include a CidrRoutingConfig pointing to this record
+        rrsets = [
+            {
+                'AliasTarget': {
+                    'DNSName': '_octodns-internal-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2',
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': 'col-1234',
+                    'LocationName': 'r0',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '0-internal-subnet',
+                'Type': 'A',
+            }
+        ]
+
+        provider._r53_rrsets = {'z44': rrsets}
+
+        # Desired subnets are different from existing (drift)
+        result = provider._extra_changes_dynamic_needs_update('z44', record)
+        self.assertTrue(result)
+
+    def test_extra_changes_cidr_no_drift(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        provider._health_checks = {}
+        provider._cidr_collections = {
+            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+        }
+
+        zone = Zone('unit.tests.', [])
+        subnet_record_data = {
+            'dynamic': {
+                'pools': {
+                    'internal': {
+                        'values': [
+                            {'weight': 1, 'value': '10.0.0.1', 'status': 'up'}
+                        ]
+                    },
+                    'external': {
+                        'values': [
+                            {'weight': 1, 'value': '2.2.2.2', 'status': 'up'}
+                        ]
+                    },
+                },
+                'rules': [
+                    {
+                        'pool': 'internal',
+                        'subnets': ['10.0.0.0/8', '172.16.0.0/12'],
+                    },
+                    {'pool': 'external'},
+                ],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': ['1.1.2.1', '1.1.2.2'],
+        }
+        record = Record.new(zone, '', subnet_record_data)
+
+        rrsets = [
+            {
+                'AliasTarget': {
+                    'DNSName': '_octodns-internal-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2',
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': 'col-1234',
+                    'LocationName': 'r0',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '0-internal-subnet',
+                'Type': 'A',
+            }
+        ]
+
+        provider._r53_rrsets = {'z44': rrsets}
+
+        # No drift - same subnets
+        result = provider._extra_changes_dynamic_needs_update('z44', record)
+        self.assertFalse(result)
+
+    def test_extra_changes_cidr_wrong_record(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        provider._health_checks = {}
+        provider._cidr_collections = {}
+
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            'other',
+            {
+                'dynamic': {
+                    'pools': {
+                        'p': {
+                            'values': [
+                                {
+                                    'weight': 1,
+                                    'value': '1.1.1.1',
+                                    'status': 'up',
+                                }
+                            ]
+                        }
+                    },
+                    'rules': [{'pool': 'p'}],
+                },
+                'ttl': 60,
+                'type': 'A',
+                'values': ['1.1.1.1'],
+            },
+        )
+
+        # CIDR rrset for a different record (unit.tests. not other.unit.tests.)
+        rrsets = [
+            {
+                'AliasTarget': {
+                    'DNSName': '_octodns-internal-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2',
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': 'col-1234',
+                    'LocationName': 'r0',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '0-internal-subnet',
+                'Type': 'A',
+            }
+        ]
+
+        provider._r53_rrsets = {'z44': rrsets}
+
+        result = provider._extra_changes_dynamic_needs_update('z44', record)
+        self.assertFalse(result)
+
+    def test_extra_changes_cidr_rule_index_out_of_range(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        provider._health_checks = {}
+        provider._cidr_collections = {'col-1234': {'r5': ['10.0.0.0/8']}}
+
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            '',
+            {
+                'dynamic': {
+                    'pools': {
+                        'p': {
+                            'values': [
+                                {
+                                    'weight': 1,
+                                    'value': '1.1.1.1',
+                                    'status': 'up',
+                                }
+                            ]
+                        }
+                    },
+                    'rules': [{'pool': 'p'}],
+                },
+                'ttl': 60,
+                'type': 'A',
+                'values': ['1.1.1.1'],
+            },
+        )
+
+        # Rule index 5 is beyond the record's rules list
+        rrsets = [
+            {
+                'AliasTarget': {
+                    'DNSName': '_octodns-p-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2',
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': 'col-1234',
+                    'LocationName': 'r5',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '5-p-subnet',
+                'Type': 'A',
+            }
+        ]
+
+        provider._r53_rrsets = {'z44': rrsets}
+
+        result = provider._extra_changes_dynamic_needs_update('z44', record)
+        self.assertFalse(result)
+
+    def test_extra_changes_cidr_wrong_type(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        provider._health_checks = {}
+        provider._cidr_collections = {}
+
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            '',
+            {
+                'dynamic': {
+                    'pools': {
+                        'p': {
+                            'values': [
+                                {'weight': 1, 'value': '::1', 'status': 'up'}
+                            ]
+                        }
+                    },
+                    'rules': [{'pool': 'p'}],
+                },
+                'ttl': 60,
+                'type': 'AAAA',
+                'values': ['::1'],
+            },
+        )
+
+        # CIDR rrset with wrong type (A vs AAAA)
+        rrsets = [
+            {
+                'AliasTarget': {
+                    'DNSName': '_octodns-internal-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2',
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': 'col-1234',
+                    'LocationName': 'r0',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '0-internal-subnet',
+                'Type': 'A',
+            }
+        ]
+
+        provider._r53_rrsets = {'z44': rrsets}
+
+        result = provider._extra_changes_dynamic_needs_update('z44', record)
+        self.assertFalse(result)
+
+    def test_apply_with_subnet_records(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        provider._health_checks = {}
+        provider.get_health_check_id = lambda r, v, s, c: None
+        provider._r53_zones = {'unit.tests.': '/hostedzone/z42'}
+
+        zone = Zone('unit.tests.', [])
+        subnet_record_data = {
+            'dynamic': {
+                'pools': {
+                    'internal': {
+                        'values': [
+                            {'weight': 1, 'value': '10.0.0.1', 'status': 'up'}
+                        ]
+                    },
+                    'external': {
+                        'values': [
+                            {'weight': 1, 'value': '2.2.2.2', 'status': 'up'}
+                        ]
+                    },
+                },
+                'rules': [
+                    {'pool': 'internal', 'subnets': ['10.0.0.0/8']},
+                    {'pool': 'external'},
+                ],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': ['1.1.2.1'],
+        }
+        record = Record.new(zone, '', subnet_record_data)
+        zone.add_record(record)
+
+        plan = Mock()
+        plan.desired = zone
+        plan.changes = [Create(record)]
+
+        # Stub: list_cidr_collections (find existing)
+        stubber.add_response(
+            'list_cidr_collections',
+            {
+                'CidrCollections': [
+                    {
+                        'Id': 'col-1234',
+                        'Name': 'octodns-unit-tests',
+                        'Arn': 'arn:aws:route53:::cidrcollection/col-1234',
+                        'Version': 1,
+                    }
+                ]
+            },
+        )
+        # Stub: list_cidr_blocks (to compute diff)
+        stubber.add_response(
+            'list_cidr_blocks', {'CidrBlocks': []}, {'CollectionId': 'col-1234'}
+        )
+        # Stub: change_cidr_collection (to sync)
+        stubber.add_response(
+            'change_cidr_collection',
+            {'Id': 'change-1'},
+            {
+                'Id': 'col-1234',
+                'Changes': [
+                    {
+                        'LocationName': 'r0',
+                        'Action': 'PUT',
+                        'CidrList': ['10.0.0.0/8'],
+                    }
+                ],
+            },
+        )
+        # Stub: load_records (existing rrsets)
+        stubber.add_response(
+            'list_resource_record_sets',
+            {'ResourceRecordSets': [], 'IsTruncated': False, 'MaxItems': '100'},
+            {'HostedZoneId': '/hostedzone/z42'},
+        )
+        # Stub: change_resource_record_sets (apply)
+        stubber.add_response(
+            'change_resource_record_sets',
+            {
+                'ChangeInfo': {
+                    'Id': 'change-1',
+                    'Status': 'PENDING',
+                    'SubmittedAt': '2024-01-01T00:00:00Z',
+                }
+            },
+        )
+
+        provider._apply(plan)
+        self.assertEqual('col-1234', provider._current_cidr_collection_id)
+        stubber.assert_no_pending_responses()
+
     def test_mod_Update_set_math(self):
         provider = Route53Provider('test', 'abc', '123')
 
@@ -4995,6 +5762,129 @@ class TestRoute53Records(TestCase):
             # Smoke test stringification
             route53_record.__repr__()
 
+    def test_dynamic_subnet_rule(self):
+        provider = DummyProvider()
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone, '', {'ttl': 60, 'type': 'A', 'values': ['1.1.1.1']}
+        )
+
+        rule = _Route53DynamicSubnetRule(
+            provider, 'Z2', record, 'internal', 0, True, 'col-1234'
+        )
+
+        self.assertEqual('0-internal-subnet', rule.identifer)
+        self.assertEqual(
+            '_octodns-internal-pool.unit.tests.', rule.target_dns_name
+        )
+
+        mod = rule.mod('CREATE', [])
+        self.assertEqual('CREATE', mod['Action'])
+        rrset = mod['ResourceRecordSet']
+        self.assertEqual('unit.tests.', rrset['Name'])
+        self.assertEqual('A', rrset['Type'])
+        self.assertEqual('0-internal-subnet', rrset['SetIdentifier'])
+        self.assertEqual(
+            {
+                'DNSName': '_octodns-internal-pool.unit.tests.',
+                'EvaluateTargetHealth': True,
+                'HostedZoneId': 'Z2',
+            },
+            rrset['AliasTarget'],
+        )
+        self.assertEqual(
+            {'CollectionId': 'col-1234', 'LocationName': 'r0'},
+            rrset['CidrRoutingConfig'],
+        )
+
+        # Test __hash__ - same identifer means same hash
+        rule2 = _Route53DynamicSubnetRule(
+            provider, 'Z2', record, 'internal', 0, True, 'col-1234'
+        )
+        self.assertEqual(hash(rule), hash(rule2))
+
+        # Test __repr__
+        repr_str = repr(rule)
+        self.assertIn('_Route53DynamicSubnetRule', repr_str)
+        self.assertIn('unit.tests.', repr_str)
+
+    def test_new_dynamic_subnets(self):
+        provider = Route53Provider('test', 'abc', '123')
+        stubber = Stubber(provider._conn)
+        stubber.activate()
+
+        provider._health_checks = {}
+        provider.get_health_check_id = lambda r, v, s, c: 'hc42'
+
+        zone = Zone('unit.tests.', [])
+        subnet_record_data = {
+            'dynamic': {
+                'pools': {
+                    'internal': {
+                        'values': [
+                            {'weight': 1, 'value': '10.0.0.1', 'status': 'up'}
+                        ]
+                    },
+                    'external': {
+                        'values': [
+                            {'weight': 1, 'value': '2.2.2.2', 'status': 'up'}
+                        ]
+                    },
+                },
+                'rules': [
+                    {
+                        'pool': 'internal',
+                        'subnets': ['10.0.0.0/8', '172.16.0.0/12'],
+                    },
+                    {'pool': 'external'},
+                ],
+            },
+            'ttl': 60,
+            'type': 'A',
+            'values': ['1.1.2.1', '1.1.2.2'],
+        }
+        record = Record.new(zone, '', subnet_record_data)
+
+        route53_records = _Route53Record.new(
+            provider, record, 'z45', creating=True, collection_id='col-1234'
+        )
+
+        expected_mods = [r.mod('CREATE', []) for r in route53_records]
+        expected_mods.sort(key=_mod_keyer)
+
+        # Should have:
+        # 1 default pool + 2 pool values + 2 pool primaries + 2 pool
+        # secondaries + 1 subnet rule + 1 geo catchall = 9
+        self.assertEqual(9, len(route53_records))
+
+        # Verify there's a CidrRoutingConfig mod
+        cidr_mods = [
+            m
+            for m in expected_mods
+            if 'CidrRoutingConfig' in m['ResourceRecordSet']
+        ]
+        self.assertEqual(1, len(cidr_mods))
+        cidr_rrset = cidr_mods[0]['ResourceRecordSet']
+        self.assertEqual(
+            {'CollectionId': 'col-1234', 'LocationName': 'r0'},
+            cidr_rrset['CidrRoutingConfig'],
+        )
+        self.assertEqual('0-internal-subnet', cidr_rrset['SetIdentifier'])
+
+        # Verify the catchall geo rule still exists
+        geo_mods = [
+            m for m in expected_mods if 'GeoLocation' in m['ResourceRecordSet']
+        ]
+        self.assertEqual(1, len(geo_mods))
+        self.assertEqual(
+            {'CountryCode': '*'},
+            geo_mods[0]['ResourceRecordSet']['GeoLocation'],
+        )
+
+        # Smoke test repr
+        for route53_record in route53_records:
+            route53_record.__repr__()
+
 
 class TestModKeyer(TestCase):
     def test_mod_keyer(self):
@@ -5106,6 +5996,39 @@ class TestModKeyer(TestCase):
                     'ResourceRecordSet': {
                         'GeoLocation': 'some-target',
                         'SetIdentifier': 'some-id',
+                    },
+                }
+            ),
+        )
+
+        # CidrRoutingConfig has same priority as GeoLocation
+        self.assertEqual(
+            (0, -3, 'cidr-id'),
+            _mod_keyer(
+                {
+                    'Action': 'DELETE',
+                    'ResourceRecordSet': {
+                        'CidrRoutingConfig': {
+                            'CollectionId': 'col-1',
+                            'LocationName': 'r0',
+                        },
+                        'SetIdentifier': 'cidr-id',
+                    },
+                }
+            ),
+        )
+
+        self.assertEqual(
+            (1, 3, 'cidr-id'),
+            _mod_keyer(
+                {
+                    'Action': 'UPSERT',
+                    'ResourceRecordSet': {
+                        'CidrRoutingConfig': {
+                            'CollectionId': 'col-1',
+                            'LocationName': 'r0',
+                        },
+                        'SetIdentifier': 'cidr-id',
                     },
                 }
             ),

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -412,9 +412,9 @@ dynamic_subnet_rrsets = [
             'EvaluateTargetHealth': True,
             'HostedZoneId': 'Z2',
         },
-        'GeoLocation': {'CountryCode': '*'},
+        'CidrRoutingConfig': {'CollectionId': 'col-1234', 'LocationName': '*'},
         'Name': 'unit.tests.',
-        'SetIdentifier': '1-external-None',
+        'SetIdentifier': '1-external-subnet',
         'Type': 'A',
     },
 ]
@@ -4803,7 +4803,7 @@ class TestRoute53Provider(TestCase):
                     {
                         'LocationName': 'r0',
                         'Action': 'PUT',
-                        'CidrList': ['10.0.0.0/8', '172.16.0.0/12'],
+                        'CidrList': ['172.16.0.0/12'],
                     },
                     {
                         'LocationName': 'r1',
@@ -4818,6 +4818,69 @@ class TestRoute53Provider(TestCase):
         provider._sync_cidr_locations('col-1234', desired)
 
         # Cache should be invalidated
+        self.assertNotIn('col-1234', provider._cidr_collections)
+        stubber.assert_no_pending_responses()
+
+    def test_sync_cidr_locations_replace_blocks(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        # r0 has old blocks that need full replacement
+        provider._cidr_collections = {
+            'col-1234': {'r0': ['40.71.0.0/16', '10.0.0.0/8']}
+        }
+
+        stubber.add_response(
+            'change_cidr_collection',
+            {'Id': 'change-id-1234'},
+            {
+                'Id': 'col-1234',
+                'Changes': [
+                    {
+                        'LocationName': 'r0',
+                        'Action': 'DELETE_IF_EXISTS',
+                        'CidrList': ['10.0.0.0/8', '40.71.0.0/16'],
+                    },
+                    {
+                        'LocationName': 'r0',
+                        'Action': 'PUT',
+                        'CidrList': ['97.120.173.0/24'],
+                    },
+                ],
+            },
+        )
+
+        desired = {'r0': ['97.120.173.0/24']}
+        provider._sync_cidr_locations('col-1234', desired)
+
+        self.assertNotIn('col-1234', provider._cidr_collections)
+        stubber.assert_no_pending_responses()
+
+    def test_sync_cidr_locations_remove_blocks(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        # r0 has extra blocks that need removing, no new ones to add
+        provider._cidr_collections = {
+            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+        }
+
+        stubber.add_response(
+            'change_cidr_collection',
+            {'Id': 'change-id-1234'},
+            {
+                'Id': 'col-1234',
+                'Changes': [
+                    {
+                        'LocationName': 'r0',
+                        'Action': 'DELETE_IF_EXISTS',
+                        'CidrList': ['172.16.0.0/12'],
+                    }
+                ],
+            },
+        )
+
+        desired = {'r0': ['10.0.0.0/8']}
+        provider._sync_cidr_locations('col-1234', desired)
+
         self.assertNotIn('col-1234', provider._cidr_collections)
         stubber.assert_no_pending_responses()
 
@@ -4940,6 +5003,7 @@ class TestRoute53Provider(TestCase):
         record = Record.new(zone, '', subnet_record_data)
 
         # RRsets that include a CidrRoutingConfig pointing to this record
+        # plus a default catchall with LocationName '*'
         rrsets = [
             {
                 'AliasTarget': {
@@ -4954,7 +5018,21 @@ class TestRoute53Provider(TestCase):
                 'Name': 'unit.tests.',
                 'SetIdentifier': '0-internal-subnet',
                 'Type': 'A',
-            }
+            },
+            {
+                'AliasTarget': {
+                    'DNSName': '_octodns-external-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2',
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': 'col-1234',
+                    'LocationName': '*',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '1-external-subnet',
+                'Type': 'A',
+            },
         ]
 
         provider._r53_rrsets = {'z44': rrsets}
@@ -5017,9 +5095,27 @@ class TestRoute53Provider(TestCase):
             }
         ]
 
+        # Add default catchall with LocationName '*'
+        rrsets.append(
+            {
+                'AliasTarget': {
+                    'DNSName': '_octodns-external-pool.unit.tests.',
+                    'EvaluateTargetHealth': True,
+                    'HostedZoneId': 'Z2',
+                },
+                'CidrRoutingConfig': {
+                    'CollectionId': 'col-1234',
+                    'LocationName': '*',
+                },
+                'Name': 'unit.tests.',
+                'SetIdentifier': '1-external-subnet',
+                'Type': 'A',
+            }
+        )
+
         provider._r53_rrsets = {'z44': rrsets}
 
-        # No drift - same subnets
+        # No drift - same subnets, default catchall is skipped
         result = provider._extra_changes_dynamic_needs_update('z44', record)
         self.assertFalse(result)
 
@@ -5853,32 +5949,53 @@ class TestRoute53Records(TestCase):
 
         # Should have:
         # 1 default pool + 2 pool values + 2 pool primaries + 2 pool
-        # secondaries + 1 subnet rule + 1 geo catchall = 9
+        # secondaries + 1 subnet rule + 1 subnet catchall = 9
         self.assertEqual(9, len(route53_records))
 
-        # Verify there's a CidrRoutingConfig mod
+        # Verify there are 2 CidrRoutingConfig mods (subnet rule + catchall)
         cidr_mods = [
             m
             for m in expected_mods
             if 'CidrRoutingConfig' in m['ResourceRecordSet']
         ]
-        self.assertEqual(1, len(cidr_mods))
-        cidr_rrset = cidr_mods[0]['ResourceRecordSet']
+        self.assertEqual(2, len(cidr_mods))
+
+        # Find the subnet rule and the catchall by LocationName
+        subnet_rule = [
+            m
+            for m in cidr_mods
+            if m['ResourceRecordSet']['CidrRoutingConfig']['LocationName']
+            != '*'
+        ]
+        catchall = [
+            m
+            for m in cidr_mods
+            if m['ResourceRecordSet']['CidrRoutingConfig']['LocationName']
+            == '*'
+        ]
+        self.assertEqual(1, len(subnet_rule))
+        self.assertEqual(1, len(catchall))
+
+        cidr_rrset = subnet_rule[0]['ResourceRecordSet']
         self.assertEqual(
             {'CollectionId': 'col-1234', 'LocationName': 'r0'},
             cidr_rrset['CidrRoutingConfig'],
         )
         self.assertEqual('0-internal-subnet', cidr_rrset['SetIdentifier'])
 
-        # Verify the catchall geo rule still exists
+        # Verify the catchall uses CidrRoutingConfig with LocationName '*'
+        catchall_rrset = catchall[0]['ResourceRecordSet']
+        self.assertEqual(
+            {'CollectionId': 'col-1234', 'LocationName': '*'},
+            catchall_rrset['CidrRoutingConfig'],
+        )
+        self.assertEqual('1-external-subnet', catchall_rrset['SetIdentifier'])
+
+        # Verify no GeoLocation mods exist (all routing is CIDR-based)
         geo_mods = [
             m for m in expected_mods if 'GeoLocation' in m['ResourceRecordSet']
         ]
-        self.assertEqual(1, len(geo_mods))
-        self.assertEqual(
-            {'CountryCode': '*'},
-            geo_mods[0]['ResourceRecordSet']['GeoLocation'],
-        )
+        self.assertEqual(0, len(geo_mods))
 
         # Smoke test repr
         for route53_record in route53_records:

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -401,7 +401,10 @@ dynamic_subnet_rrsets = [
             'EvaluateTargetHealth': True,
             'HostedZoneId': 'Z2',
         },
-        'CidrRoutingConfig': {'CollectionId': 'col-1234', 'LocationName': 'r0'},
+        'CidrRoutingConfig': {
+            'CollectionId': 'col-1234',
+            'LocationName': '0d6919570ce514c0',
+        },
         'Name': 'unit.tests.',
         'SetIdentifier': '0-internal-subnet',
         'Type': 'A',
@@ -4638,7 +4641,7 @@ class TestRoute53Provider(TestCase):
         provider = Route53Provider('test', 'abc', '123')
         provider._health_checks = {}
         provider._cidr_collections = {
-            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+            'col-1234': {'0d6919570ce514c0': ['10.0.0.0/8', '172.16.0.0/12']}
         }
 
         data = provider._data_for_dynamic('', 'A', dynamic_subnet_rrsets)
@@ -4671,7 +4674,7 @@ class TestRoute53Provider(TestCase):
         provider = Route53Provider('test', 'abc', '123')
         provider._health_checks = {}
         provider._cidr_collections = {
-            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+            'col-1234': {'0d6919570ce514c0': ['10.0.0.0/8', '172.16.0.0/12']}
         }
 
         get_zone_id_mock.side_effect = ['z44']
@@ -4695,14 +4698,21 @@ class TestRoute53Provider(TestCase):
         # Verify default rule
         self.assertEqual({'pool': 'external'}, rules[1])
 
-    def test_cidr_collection_name(self):
+    def test_cidr_location_name(self):
+        self.assertEqual('octodns', Route53Provider._CIDR_COLLECTION_NAME)
+        # Deterministic
+        h = Route53Provider._cidr_location_name(['10.0.0.0/8'])
+        self.assertEqual(h, Route53Provider._cidr_location_name(['10.0.0.0/8']))
+        # 16-char hex
+        self.assertEqual(16, len(h))
+        # Order-independent
         self.assertEqual(
-            'octodns-unit-tests',
-            Route53Provider._cidr_collection_name('unit.tests.'),
-        )
-        self.assertEqual(
-            'octodns-sub-unit-tests',
-            Route53Provider._cidr_collection_name('sub.unit.tests.'),
+            Route53Provider._cidr_location_name(
+                ['172.16.0.0/12', '10.0.0.0/8']
+            ),
+            Route53Provider._cidr_location_name(
+                ['10.0.0.0/8', '172.16.0.0/12']
+            ),
         )
 
     def test_get_cidr_collection(self):
@@ -4710,7 +4720,7 @@ class TestRoute53Provider(TestCase):
 
         collection_summary = {
             'Id': 'col-1234',
-            'Name': 'octodns-unit-tests',
+            'Name': 'octodns',
             'Arn': 'arn:aws:route53:::cidrcollection/col-1234',
             'Version': 1,
         }
@@ -4719,7 +4729,7 @@ class TestRoute53Provider(TestCase):
         stubber.add_response(
             'list_cidr_collections', {'CidrCollections': [collection_summary]}
         )
-        result = provider._get_cidr_collection('unit.tests.')
+        result = provider._get_cidr_collection()
         self.assertEqual('col-1234', result)
 
         # Collection doesn't exist
@@ -4736,7 +4746,7 @@ class TestRoute53Provider(TestCase):
                 ]
             },
         )
-        result = provider._get_cidr_collection('unit.tests.')
+        result = provider._get_cidr_collection()
         self.assertIsNone(result)
 
         # Paginated response
@@ -4760,14 +4770,14 @@ class TestRoute53Provider(TestCase):
                 'CidrCollections': [
                     {
                         'Id': 'col-found',
-                        'Name': 'octodns-unit-tests',
+                        'Name': 'octodns',
                         'Arn': 'arn:aws:route53:::cidrcollection/col-found',
                         'Version': 1,
                     }
                 ]
             },
         )
-        result = provider._get_cidr_collection('unit.tests.')
+        result = provider._get_cidr_collection()
         self.assertEqual('col-found', result)
 
         stubber.assert_no_pending_responses()
@@ -4780,14 +4790,14 @@ class TestRoute53Provider(TestCase):
             {
                 'Collection': {
                     'Id': 'col-new',
-                    'Name': 'octodns-unit-tests',
+                    'Name': 'octodns',
                     'Arn': 'arn:aws:route53:::cidrcollection/col-new',
                     'Version': 1,
                 },
                 'Location': 'https://route53.amazonaws.com/cidrcollection/col-new',
             },
         )
-        result = provider._create_cidr_collection('unit.tests.')
+        result = provider._create_cidr_collection()
         self.assertEqual('col-new', result)
         stubber.assert_no_pending_responses()
 
@@ -4820,9 +4830,14 @@ class TestRoute53Provider(TestCase):
     def test_sync_cidr_locations(self):
         provider, stubber = self._get_stubbed_provider()
 
-        # Pre-populate cache with existing state
+        loc = '0d6919570ce514c0'
+
+        # Pre-populate cache with existing state (stale location left alone)
         provider._cidr_collections = {
-            'col-1234': {'r0': ['10.0.0.0/8'], 'r1': ['192.168.0.0/16']}
+            'col-1234': {
+                loc: ['10.0.0.0/8'],
+                'da3508145559327a': ['192.168.0.0/16'],
+            }
         }
 
         stubber.add_response(
@@ -4832,20 +4847,15 @@ class TestRoute53Provider(TestCase):
                 'Id': 'col-1234',
                 'Changes': [
                     {
-                        'LocationName': 'r0',
+                        'LocationName': loc,
                         'Action': 'PUT',
                         'CidrList': ['172.16.0.0/12'],
-                    },
-                    {
-                        'LocationName': 'r1',
-                        'Action': 'DELETE_IF_EXISTS',
-                        'CidrList': ['192.168.0.0/16'],
-                    },
+                    }
                 ],
             },
         )
 
-        desired = {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+        desired = {loc: ['10.0.0.0/8', '172.16.0.0/12']}
         provider._sync_cidr_locations('col-1234', desired)
 
         # Cache should be invalidated
@@ -4855,9 +4865,11 @@ class TestRoute53Provider(TestCase):
     def test_sync_cidr_locations_replace_blocks(self):
         provider, stubber = self._get_stubbed_provider()
 
-        # r0 has old blocks that need full replacement
+        loc = '7bc59b45c0e21e40'
+
+        # Location has old blocks that need full replacement
         provider._cidr_collections = {
-            'col-1234': {'r0': ['40.71.0.0/16', '10.0.0.0/8']}
+            'col-1234': {loc: ['40.71.0.0/16', '10.0.0.0/8']}
         }
 
         stubber.add_response(
@@ -4867,12 +4879,12 @@ class TestRoute53Provider(TestCase):
                 'Id': 'col-1234',
                 'Changes': [
                     {
-                        'LocationName': 'r0',
+                        'LocationName': loc,
                         'Action': 'DELETE_IF_EXISTS',
                         'CidrList': ['10.0.0.0/8', '40.71.0.0/16'],
                     },
                     {
-                        'LocationName': 'r0',
+                        'LocationName': loc,
                         'Action': 'PUT',
                         'CidrList': ['97.120.173.0/24'],
                     },
@@ -4880,7 +4892,7 @@ class TestRoute53Provider(TestCase):
             },
         )
 
-        desired = {'r0': ['97.120.173.0/24']}
+        desired = {loc: ['97.120.173.0/24']}
         provider._sync_cidr_locations('col-1234', desired)
 
         self.assertNotIn('col-1234', provider._cidr_collections)
@@ -4889,9 +4901,11 @@ class TestRoute53Provider(TestCase):
     def test_sync_cidr_locations_remove_blocks(self):
         provider, stubber = self._get_stubbed_provider()
 
-        # r0 has extra blocks that need removing, no new ones to add
+        loc = '93997fe8a8121085'
+
+        # Location has extra blocks that need removing, no new ones to add
         provider._cidr_collections = {
-            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
+            'col-1234': {loc: ['10.0.0.0/8', '172.16.0.0/12']}
         }
 
         stubber.add_response(
@@ -4901,7 +4915,7 @@ class TestRoute53Provider(TestCase):
                 'Id': 'col-1234',
                 'Changes': [
                     {
-                        'LocationName': 'r0',
+                        'LocationName': loc,
                         'Action': 'DELETE_IF_EXISTS',
                         'CidrList': ['172.16.0.0/12'],
                     }
@@ -4909,7 +4923,7 @@ class TestRoute53Provider(TestCase):
             },
         )
 
-        desired = {'r0': ['10.0.0.0/8']}
+        desired = {loc: ['10.0.0.0/8']}
         provider._sync_cidr_locations('col-1234', desired)
 
         self.assertNotIn('col-1234', provider._cidr_collections)
@@ -4918,10 +4932,12 @@ class TestRoute53Provider(TestCase):
     def test_sync_cidr_locations_no_changes(self):
         provider, stubber = self._get_stubbed_provider()
 
-        # Pre-populate cache - already matches desired
-        provider._cidr_collections = {'col-1234': {'r0': ['10.0.0.0/8']}}
+        loc = '93997fe8a8121085'
 
-        desired = {'r0': ['10.0.0.0/8']}
+        # Pre-populate cache - already matches desired
+        provider._cidr_collections = {'col-1234': {loc: ['10.0.0.0/8']}}
+
+        desired = {loc: ['10.0.0.0/8']}
         provider._sync_cidr_locations('col-1234', desired)
 
         # No API call should be made, cache should remain
@@ -4938,14 +4954,14 @@ class TestRoute53Provider(TestCase):
                 'CidrCollections': [
                     {
                         'Id': 'col-existing',
-                        'Name': 'octodns-unit-tests',
+                        'Name': 'octodns',
                         'Arn': 'arn:aws:route53:::cidrcollection/col-existing',
                         'Version': 1,
                     }
                 ]
             },
         )
-        result = provider._get_or_create_cidr_collection('unit.tests.')
+        result = provider._get_or_create_cidr_collection()
         self.assertEqual('col-existing', result)
         stubber.assert_no_pending_responses()
 
@@ -4960,14 +4976,14 @@ class TestRoute53Provider(TestCase):
             {
                 'Collection': {
                     'Id': 'col-new',
-                    'Name': 'octodns-unit-tests',
+                    'Name': 'octodns',
                     'Arn': 'arn:aws:route53:::cidrcollection/col-new',
                     'Version': 1,
                 },
                 'Location': 'https://route53.amazonaws.com/cidrcollection/col-new',
             },
         )
-        result = provider._get_or_create_cidr_collection('unit.tests.')
+        result = provider._get_or_create_cidr_collection()
         self.assertEqual('col-new', result)
         stubber.assert_no_pending_responses()
 
@@ -5002,7 +5018,7 @@ class TestRoute53Provider(TestCase):
         provider, stubber = self._get_stubbed_provider()
 
         provider._health_checks = {}
-        provider._cidr_collections = {'col-1234': {'r0': ['10.0.0.0/8']}}
+        provider._cidr_collections = {}
 
         zone = Zone('unit.tests.', [])
         subnet_record_data = {
@@ -5044,7 +5060,7 @@ class TestRoute53Provider(TestCase):
                 },
                 'CidrRoutingConfig': {
                     'CollectionId': 'col-1234',
-                    'LocationName': 'r0',
+                    'LocationName': '93997fe8a8121085',
                 },
                 'Name': 'unit.tests.',
                 'SetIdentifier': '0-internal-subnet',
@@ -5068,7 +5084,7 @@ class TestRoute53Provider(TestCase):
 
         provider._r53_rrsets = {'z44': rrsets}
 
-        # Desired subnets are different from existing (drift)
+        # Desired subnets hash differently from existing LocationName (drift)
         result = provider._extra_changes_dynamic_needs_update('z44', record)
         self.assertTrue(result)
 
@@ -5076,9 +5092,7 @@ class TestRoute53Provider(TestCase):
         provider, stubber = self._get_stubbed_provider()
 
         provider._health_checks = {}
-        provider._cidr_collections = {
-            'col-1234': {'r0': ['10.0.0.0/8', '172.16.0.0/12']}
-        }
+        provider._cidr_collections = {}
 
         zone = Zone('unit.tests.', [])
         subnet_record_data = {
@@ -5118,7 +5132,7 @@ class TestRoute53Provider(TestCase):
                 },
                 'CidrRoutingConfig': {
                     'CollectionId': 'col-1234',
-                    'LocationName': 'r0',
+                    'LocationName': '0d6919570ce514c0',
                 },
                 'Name': 'unit.tests.',
                 'SetIdentifier': '0-internal-subnet',
@@ -5191,7 +5205,7 @@ class TestRoute53Provider(TestCase):
                 },
                 'CidrRoutingConfig': {
                     'CollectionId': 'col-1234',
-                    'LocationName': 'r0',
+                    'LocationName': '93997fe8a8121085',
                 },
                 'Name': 'unit.tests.',
                 'SetIdentifier': '0-internal-subnet',
@@ -5208,7 +5222,7 @@ class TestRoute53Provider(TestCase):
         provider, stubber = self._get_stubbed_provider()
 
         provider._health_checks = {}
-        provider._cidr_collections = {'col-1234': {'r5': ['10.0.0.0/8']}}
+        provider._cidr_collections = {}
 
         zone = Zone('unit.tests.', [])
         record = Record.new(
@@ -5245,7 +5259,7 @@ class TestRoute53Provider(TestCase):
                 },
                 'CidrRoutingConfig': {
                     'CollectionId': 'col-1234',
-                    'LocationName': 'r5',
+                    'LocationName': '93997fe8a8121085',
                 },
                 'Name': 'unit.tests.',
                 'SetIdentifier': '5-p-subnet',
@@ -5295,7 +5309,7 @@ class TestRoute53Provider(TestCase):
                 },
                 'CidrRoutingConfig': {
                     'CollectionId': 'col-1234',
-                    'LocationName': 'r0',
+                    'LocationName': '93997fe8a8121085',
                 },
                 'Name': 'unit.tests.',
                 'SetIdentifier': '0-internal-subnet',
@@ -5353,7 +5367,7 @@ class TestRoute53Provider(TestCase):
                 'CidrCollections': [
                     {
                         'Id': 'col-1234',
-                        'Name': 'octodns-unit-tests',
+                        'Name': 'octodns',
                         'Arn': 'arn:aws:route53:::cidrcollection/col-1234',
                         'Version': 1,
                     }
@@ -5372,7 +5386,7 @@ class TestRoute53Provider(TestCase):
                 'Id': 'col-1234',
                 'Changes': [
                     {
-                        'LocationName': 'r0',
+                        'LocationName': '93997fe8a8121085',
                         'Action': 'PUT',
                         'CidrList': ['10.0.0.0/8'],
                     }
@@ -5461,22 +5475,13 @@ class TestRoute53Provider(TestCase):
                 'CidrCollections': [
                     {
                         'Id': 'col-1234',
-                        'Name': 'octodns-unit-tests',
+                        'Name': 'octodns',
                         'Arn': 'arn:aws:route53:::cidrcollection/col-1234',
                         'Version': 1,
                     }
                 ]
             },
         )
-        # Stub: list_cidr_blocks (existing locations in collection)
-        stubber.add_response(
-            'list_cidr_blocks',
-            {'CidrBlocks': [{'CidrBlock': '10.0.0.0/8', 'LocationName': 'r0'}]},
-        )
-        # Stub: change_cidr_collection (delete stale location)
-        stubber.add_response('change_cidr_collection', {'Id': 'change-cidr-1'})
-        # Stub: delete_cidr_collection (remove empty collection)
-        stubber.add_response('delete_cidr_collection', {})
         # Stub: load_records (existing rrsets)
         stubber.add_response(
             'list_resource_record_sets',
@@ -5994,7 +5999,14 @@ class TestRoute53Records(TestCase):
         )
 
         rule = _Route53DynamicSubnetRule(
-            provider, 'Z2', record, 'internal', 0, True, 'col-1234'
+            provider,
+            'Z2',
+            record,
+            'internal',
+            0,
+            True,
+            'col-1234',
+            location_name='93997fe8a8121085',
         )
 
         self.assertEqual('0-internal-subnet', rule.identifer)
@@ -6017,13 +6029,20 @@ class TestRoute53Records(TestCase):
             rrset['AliasTarget'],
         )
         self.assertEqual(
-            {'CollectionId': 'col-1234', 'LocationName': 'r0'},
+            {'CollectionId': 'col-1234', 'LocationName': '93997fe8a8121085'},
             rrset['CidrRoutingConfig'],
         )
 
         # Test __hash__ - same identifer means same hash
         rule2 = _Route53DynamicSubnetRule(
-            provider, 'Z2', record, 'internal', 0, True, 'col-1234'
+            provider,
+            'Z2',
+            record,
+            'internal',
+            0,
+            True,
+            'col-1234',
+            location_name='93997fe8a8121085',
         )
         self.assertEqual(hash(rule), hash(rule2))
 
@@ -6107,7 +6126,7 @@ class TestRoute53Records(TestCase):
 
         cidr_rrset = subnet_rule[0]['ResourceRecordSet']
         self.assertEqual(
-            {'CollectionId': 'col-1234', 'LocationName': 'r0'},
+            {'CollectionId': 'col-1234', 'LocationName': '0d6919570ce514c0'},
             cidr_rrset['CidrRoutingConfig'],
         )
         self.assertEqual('0-internal-subnet', cidr_rrset['SetIdentifier'])

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -4862,12 +4862,12 @@ class TestRoute53Provider(TestCase):
         self.assertNotIn('col-1234', provider._cidr_collections)
         stubber.assert_no_pending_responses()
 
-    def test_sync_cidr_locations_replace_blocks(self):
+    def test_sync_cidr_locations_add_blocks(self):
         provider, stubber = self._get_stubbed_provider()
 
         loc = '7bc59b45c0e21e40'
 
-        # Location has old blocks that need full replacement
+        # Location has existing blocks, new ones need adding
         provider._cidr_collections = {
             'col-1234': {loc: ['40.71.0.0/16', '10.0.0.0/8']}
         }
@@ -4880,53 +4880,34 @@ class TestRoute53Provider(TestCase):
                 'Changes': [
                     {
                         'LocationName': loc,
-                        'Action': 'DELETE_IF_EXISTS',
-                        'CidrList': ['10.0.0.0/8', '40.71.0.0/16'],
-                    },
-                    {
-                        'LocationName': loc,
                         'Action': 'PUT',
                         'CidrList': ['97.120.173.0/24'],
-                    },
-                ],
-            },
-        )
-
-        desired = {loc: ['97.120.173.0/24']}
-        provider._sync_cidr_locations('col-1234', desired)
-
-        self.assertNotIn('col-1234', provider._cidr_collections)
-        stubber.assert_no_pending_responses()
-
-    def test_sync_cidr_locations_remove_blocks(self):
-        provider, stubber = self._get_stubbed_provider()
-
-        loc = '93997fe8a8121085'
-
-        # Location has extra blocks that need removing, no new ones to add
-        provider._cidr_collections = {
-            'col-1234': {loc: ['10.0.0.0/8', '172.16.0.0/12']}
-        }
-
-        stubber.add_response(
-            'change_cidr_collection',
-            {'Id': 'change-id-1234'},
-            {
-                'Id': 'col-1234',
-                'Changes': [
-                    {
-                        'LocationName': loc,
-                        'Action': 'DELETE_IF_EXISTS',
-                        'CidrList': ['172.16.0.0/12'],
                     }
                 ],
             },
         )
 
-        desired = {loc: ['10.0.0.0/8']}
+        desired = {loc: ['40.71.0.0/16', '10.0.0.0/8', '97.120.173.0/24']}
         provider._sync_cidr_locations('col-1234', desired)
 
         self.assertNotIn('col-1234', provider._cidr_collections)
+        stubber.assert_no_pending_responses()
+
+    def test_sync_cidr_locations_existing_subset(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        loc = '93997fe8a8121085'
+
+        # Desired is a subset of existing, nothing to add
+        provider._cidr_collections = {
+            'col-1234': {loc: ['10.0.0.0/8', '172.16.0.0/12']}
+        }
+
+        desired = {loc: ['10.0.0.0/8']}
+        provider._sync_cidr_locations('col-1234', desired)
+
+        # No API call should be made, cache should remain
+        self.assertIn('col-1234', provider._cidr_collections)
         stubber.assert_no_pending_responses()
 
     def test_sync_cidr_locations_no_changes(self):

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -5271,7 +5271,6 @@ class TestRoute53Provider(TestCase):
         )
 
         provider._apply(plan)
-        self.assertEqual('col-1234', provider._current_cidr_collection_id)
         stubber.assert_no_pending_responses()
 
     def test_mod_Update_set_math(self):


### PR DESCRIPTION
## Summary

- Map octoDNS dynamic record subnet rules to Route53 CIDR collections and `CidrRoutingConfig` resource record sets
- Auto-manage one CIDR collection per zone with locations named by rule index (`r0`, `r1`, etc.)
- Add `_Route53DynamicSubnetRule` class parallel to `_Route53DynamicRule` for generating `CidrRoutingConfig` RRSets
- Extend `_data_for_dynamic` to parse `CidrRoutingConfig` RRSets back into octoDNS subnet data
- Detect CIDR location drift in `_extra_changes_dynamic_needs_update`

Fixes #128

## Test plan

- [x] All existing tests pass (no regressions)
- [x] 100% branch coverage maintained
- [x] New tests for CIDR collection CRUD, sync, pagination
- [x] New tests for subnet rule class, `_new_dynamic` with subnets, populate roundtrip
- [x] New tests for `_mod_keyer` with `CidrRoutingConfig`, drift detection, end-to-end `_apply`
- [ ] Manual testing against a real Route53 zone with CIDR collections