### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/02aaa489219b42bc9a5c2b7b96fe224a.md
+++ b/.changelog/02aaa489219b42bc9a5c2b7b96fe224a.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-New provider paramater, private, added to enable specifying zone type. Note that VPC associations are managed

--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/064897ac317743d78d4d754588c9c5fe.md
+++ b/.changelog/064897ac317743d78d4d754588c9c5fe.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/11b5cf3bd8a84a55bf1b9e1586d0133c.md
+++ b/.changelog/11b5cf3bd8a84a55bf1b9e1586d0133c.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/1c41794011aa4bc8971c53f5ac5eb0ed.md
+++ b/.changelog/1c41794011aa4bc8971c53f5ac5eb0ed.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add VPC-based zone filtering with vpc_id, vpc_region, and vpc_multi_action configuration options

--- a/.changelog/28f2917a5a0242d494133c2a40d3b056.md
+++ b/.changelog/28f2917a5a0242d494133c2a40d3b056.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/49b2b9ea6a734b9c9b55d9c135ee6d70.md
+++ b/.changelog/49b2b9ea6a734b9c9b55d9c135ee6d70.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/5e366ef4d980485fb94b8c9dd75d1db4.md
+++ b/.changelog/5e366ef4d980485fb94b8c9dd75d1db4.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add permission documentation to use least permissions

--- a/.changelog/676956b5c082493c9a3c32ba3b8c4732.md
+++ b/.changelog/676956b5c082493c9a3c32ba3b8c4732.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Multiple zones with the same name will now throw an error message, behavior previously would not have been deterministic

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/929515fc7a0a4fa995854a26fb145051.md
+++ b/.changelog/929515fc7a0a4fa995854a26fb145051.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add subnet/CIDR-based routing support

--- a/.changelog/b522073ebe5c4a4c998fc89d8a07380d.md
+++ b/.changelog/b522073ebe5c4a4c998fc89d8a07380d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/c33fc3a9e6054187bc1f97508fac0b5d.md
+++ b/.changelog/c33fc3a9e6054187bc1f97508fac0b5d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix README typo for AwsAcmMangingProcessor class name

--- a/.changelog/d5d2a9cd761c4c9aa33f36ff936d9db4.md
+++ b/.changelog/d5d2a9cd761c4c9aa33f36ff936d9db4.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/d637f30147d840b5b75a9691d628d959.md
+++ b/.changelog/d637f30147d840b5b75a9691d628d959.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix ns1 type-o in script/format

--- a/.changelog/deb2073cf251426aa276cb475196ca59.md
+++ b/.changelog/deb2073cf251426aa276cb475196ca59.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/eac25ba370744a05935b6c4caae2f8a2.md
+++ b/.changelog/eac25ba370744a05935b6c4caae2f8a2.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* Add subnet/CIDR-based routing support - [#129](https://github.com/octodns/octodns-route53/pull/129)
+* Add VPC-based zone filtering with vpc_id, vpc_region, and vpc_multi_action configuration options - [#124](https://github.com/octodns/octodns-route53/pull/124)
+* New provider paramater, private, added to enable specifying zone type. Note that VPC associations are managed - [#109](https://github.com/octodns/octodns-route53/pull/109)
+* Multiple zones with the same name will now throw an error message, behavior previously would not have been deterministic - [#109](https://github.com/octodns/octodns-route53/pull/109)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#108](https://github.com/octodns/octodns-route53/pull/108)
+
 ## v1.0.1 - 2025-05-05 - Only clamp when forced
 
 * Don't clamp urllib3 unless we're on 3.8 or 3.9 where it's actually needed

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -7,7 +7,7 @@ from .record import Route53AliasRecord
 from .source import Ec2Source, ElbSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.1'
+__version__ = __VERSION__ = '1.1.0'
 
 # quell warnings
 Ec2Source


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* Add subnet/CIDR-based routing support - [#129](https://github.com/octodns/octodns-route53/pull/129)
* Add VPC-based zone filtering with vpc_id, vpc_region, and vpc_multi_action configuration options - [#124](https://github.com/octodns/octodns-route53/pull/124)
* New provider paramater, private, added to enable specifying zone type. Note that VPC associations are managed - [#109](https://github.com/octodns/octodns-route53/pull/109)
* Multiple zones with the same name will now throw an error message, behavior previously would not have been deterministic - [#109](https://github.com/octodns/octodns-route53/pull/109)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#108](https://github.com/octodns/octodns-route53/pull/108)

