### PR TITLE
Work around Route53 silently ignoring UPSERTs that only add a trailing dot to a value — route those changes through DELETE+CREATE in the same ChangeBatch, see #96

### DIFF
--- a/.changelog/218df14d9bbe459a8a27ded6ce01f752.md
+++ b/.changelog/218df14d9bbe459a8a27ded6ce01f752.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Work around Route53 silently ignoring UPSERTs that only add a trailing dot to a value — route those changes through DELETE+CREATE in the same ChangeBatch, see #96

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1600,6 +1600,34 @@ class Route53Provider(_AuthMixin, BaseProvider):
         '''
         return [r.mod(action, existing_rrsets) for r in records]
 
+    def _find_simple_rrset(self, record, existing_rrsets):
+        '''Returns the first rrset matching record's fqdn+type that has no
+        SetIdentifier or AliasTarget (i.e. a plain, non-dynamic rrset), or
+        None if not found.'''
+        if not existing_rrsets:
+            return None
+        for rrset in existing_rrsets:
+            if (
+                rrset.get('Name') == record.fqdn
+                and rrset.get('Type') == record._type
+                and 'SetIdentifier' not in rrset
+                and 'AliasTarget' not in rrset
+            ):
+                return rrset
+        return None
+
+    def _only_trailing_dot_diff(self, rrset, record):
+        '''Returns True when the existing rrset and the new record's values
+        differ only by trailing dots — the case Route53's API silently ignores
+        on UPSERT.'''
+        existing = sorted(r['Value'] for r in rrset.get('ResourceRecords', []))
+        new = sorted(record.values)
+        if existing == new:
+            return False
+        return sorted(v.rstrip('.') for v in existing) == sorted(
+            v.rstrip('.') for v in new
+        )
+
     @property
     def health_checks(self):
         if self._health_checks is None:
@@ -1919,6 +1947,24 @@ class Route53Provider(_AuthMixin, BaseProvider):
         for new_record in new_records:
             if new_record in existing_records:
                 upserts.add(new_record)
+
+        # Route53 silently ignores UPSERTs whose only difference from the
+        # stored value is a trailing dot (e.g. CNAME target "foo.com" →
+        # "foo.com."). Work around it by routing those to DELETE+CREATE in
+        # the same ChangeBatch, which Route53 applies atomically.
+        # See https://github.com/octodns/octodns-route53/issues/96
+        forced = set()
+        for record in upserts:
+            rrset = self._find_simple_rrset(record, existing_rrsets)
+            if rrset is not None and self._only_trailing_dot_diff(
+                rrset, record
+            ):
+                forced.add(record)
+        if forced:
+            upserts -= forced
+            forced_existing = {er for er in existing_records if er in forced}
+            deletes |= forced_existing
+            creates |= forced
 
         return (
             self._gen_mods('DELETE', deletes, existing_rrsets)

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -5536,6 +5536,106 @@ class TestRoute53Provider(TestCase):
         self.assertEqual('DELETE', ret[0]['Action'])
         self.assertEqual('CREATE', ret[1]['Action'])
 
+    def test_mod_Update_trailing_dot_workaround(self):
+        provider = Route53Provider('test', 'abc', '123')
+        provider._gc_health_checks = lambda *a, **kw: None
+
+        zone = Zone('unit.tests.', [])
+
+        # CNAME: only difference is trailing dot on value → should force
+        # DELETE+CREATE instead of UPSERT. The existing record lacks a trailing
+        # dot (as Route53 stores it), so we need lenient to construct it.
+        cname_existing = Record.new(
+            zone,
+            'cname',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'target.unit.tests'},
+            lenient=True,
+        )
+        cname_new = Record.new(
+            zone,
+            'cname',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'target.unit.tests.'},
+        )
+        existing_rrsets = [
+            {
+                'Name': 'cname.unit.tests.',
+                'Type': 'CNAME',
+                'TTL': 300,
+                'ResourceRecords': [{'Value': 'target.unit.tests'}],
+            }
+        ]
+        change = Update(cname_existing, cname_new)
+        ret = provider._mod_Update(change, 'z42', existing_rrsets)
+        actions = [m['Action'] for m in ret]
+        self.assertIn('DELETE', actions)
+        self.assertIn('CREATE', actions)
+        self.assertNotIn('UPSERT', actions)
+
+        # MX: trailing dot on exchange portion → force DELETE+CREATE
+        mx_existing = Record.new(
+            zone,
+            'mx',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mail.unit.tests'}],
+            },
+            lenient=True,
+        )
+        mx_new = Record.new(
+            zone,
+            'mx',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mail.unit.tests.'}],
+            },
+        )
+        existing_rrsets_mx = [
+            {
+                'Name': 'mx.unit.tests.',
+                'Type': 'MX',
+                'TTL': 300,
+                'ResourceRecords': [{'Value': '10 mail.unit.tests'}],
+            }
+        ]
+        change = Update(mx_existing, mx_new)
+        ret = provider._mod_Update(change, 'z42', existing_rrsets_mx)
+        actions = [m['Action'] for m in ret]
+        self.assertIn('DELETE', actions)
+        self.assertIn('CREATE', actions)
+        self.assertNotIn('UPSERT', actions)
+
+        # CNAME real value change → should still UPSERT, not DELETE+CREATE
+        cname_different = Record.new(
+            zone,
+            'cname',
+            {'ttl': 300, 'type': 'CNAME', 'value': 'other.unit.tests.'},
+        )
+        change = Update(cname_existing, cname_different)
+        ret = provider._mod_Update(change, 'z42', existing_rrsets)
+        actions = [m['Action'] for m in ret]
+        self.assertIn('UPSERT', actions)
+        self.assertNotIn('DELETE', actions)
+        self.assertNotIn('CREATE', actions)
+
+        # Existing rrset already has the trailing dot (values are identical) →
+        # no diff, should stay as UPSERT
+        existing_rrsets_with_dot = [
+            {
+                'Name': 'cname.unit.tests.',
+                'Type': 'CNAME',
+                'TTL': 300,
+                'ResourceRecords': [{'Value': 'target.unit.tests.'}],
+            }
+        ]
+        change = Update(cname_new, cname_new)
+        ret = provider._mod_Update(change, 'z42', existing_rrsets_with_dot)
+        actions = [m['Action'] for m in ret]
+        self.assertIn('UPSERT', actions)
+        self.assertNotIn('DELETE', actions)
+        self.assertNotIn('CREATE', actions)
+
 
 class DummyProvider(object):
     def get_health_check_id(self, *args, **kwargs):


### PR DESCRIPTION

This tact didn't work, Route53 ignores it as well. See the linked issue for more detail.

/cc Fixes https://github.com/octodns/octodns-route53/issues/96#issuecomment-4390590163