### PR TITLE
Fix: Sanitize invalid characters in health check tag names

### DIFF
--- a/.changelog/5a340cceedd84371a78f4c3fa59cdbb2.md
+++ b/.changelog/5a340cceedd84371a78f4c3fa59cdbb2.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Sanitize invalid characters in health check tag names to support wildcard DNS records

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -23,11 +23,25 @@ from .record import Route53AliasRecord
 
 octal_re = re.compile(r'\\(\d\d\d)')
 
+# Route53 health check tags can only contain: letters, numbers, spaces,
+# and these special characters: _ . : / = + - @
+# https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeTagsForResource.html
+_route53_tag_invalid_chars_re = re.compile(r'[^a-zA-Z0-9 _.:/=+\-@]')
+
 
 def _octal_replace(s):
     # See http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/
     #     DomainNameFormat.html
     return octal_re.sub(lambda m: chr(int(m.group(1), 8)), s)
+
+
+def _sanitize_route53_tag_value(value):
+    # Sanitize a string for use in Route53 health check tags. Route53 tags
+    # can only contain letters, numbers, spaces, and the following special
+    # characters: _ . : / = + - @
+    # See https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeTagsForResource.html
+    # Invalid characters (like * in wildcard DNS names) are replaced with '-'
+    return _route53_tag_invalid_chars_re.sub('-', value)
 
 
 def _healthcheck_ref_prefix(version, record_type, record_fqdn):
@@ -1812,7 +1826,10 @@ class Route53Provider(_AuthMixin, BaseProvider):
 
         # Set a Name for the benefit of the UI
         value_or_host = value or healthcheck_host
-        name = f'{record.fqdn}:{record._type} - {value_or_host}'
+        # Sanitize for Route53 tag compliance (e.g., wildcard * not allowed)
+        name = _sanitize_route53_tag_value(
+            f'{record.fqdn}:{record._type} - {value_or_host}'
+        )
         self._conn.change_tags_for_resource(
             ResourceType='healthcheck',
             ResourceId=id,

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -3090,6 +3090,96 @@ class TestRoute53Provider(TestCase):
         self.assertEqual('42', id)
         stubber.assert_no_pending_responses()
 
+    def test_health_check_wildcard_record(self):
+        provider, stubber = self._get_stubbed_provider()
+
+        # Test wildcard record with health check
+        # Wildcard characters (*) are not allowed in Route53 tags
+        # Should be sanitized to avoid API errors
+
+        health_checks = []
+        stubber.add_response(
+            'list_health_checks',
+            {
+                'HealthChecks': health_checks,
+                'IsTruncated': False,
+                'MaxItems': '100',
+                'Marker': '',
+            },
+        )
+
+        health_check_config = {
+            'Disabled': False,
+            'EnableSNI': True,
+            'Inverted': False,
+            'FailureThreshold': 6,
+            'FullyQualifiedDomainName': 'api.example.com',
+            'IPAddress': '4.2.3.4',
+            'MeasureLatency': True,
+            'Port': 443,
+            'RequestInterval': 10,
+            'ResourcePath': '/_health',
+            'Type': 'HTTPS',
+        }
+        stubber.add_response(
+            'create_health_check',
+            {
+                'HealthCheck': {
+                    'Id': '44',
+                    'CallerReference': self.caller_ref,
+                    'HealthCheckConfig': health_check_config,
+                    'HealthCheckVersion': 1,
+                },
+                'Location': 'http://url',
+            },
+            {'CallerReference': ANY, 'HealthCheckConfig': health_check_config},
+        )
+
+        # Verify that the tag value is sanitized (no * characters)
+        # The sanitized name should replace * with -
+        stubber.add_response(
+            'change_tags_for_resource',
+            {},
+            {
+                'ResourceType': 'healthcheck',
+                'ResourceId': '44',
+                'AddTags': [
+                    {
+                        'Key': 'Name',
+                        'Value': '-.api.unit.tests.:A - 4.2.3.4',  # * replaced with -
+                    }
+                ],
+            },
+        )
+
+        # Create a wildcard A record with dynamic config
+        record = Record.new(
+            self.expected,
+            '*.api',  # Wildcard record name
+            {
+                'ttl': 60,
+                'type': 'A',
+                'values': ['4.2.3.4'],
+                'dynamic': {
+                    'pools': {'default': {'values': [{'value': '4.2.3.4'}]}},
+                    'rules': [{'pool': 'default'}],
+                },
+                'octodns': {
+                    'healthcheck': {
+                        'host': 'api.example.com',
+                        'path': '/_health',
+                        'port': 443,
+                        'protocol': 'HTTPS',
+                    }
+                },
+            },
+        )
+
+        value = record.dynamic.pools['default'].data['values'][0]['value']
+        id = provider.get_health_check_id(record, value, 'obey', True)
+        self.assertEqual('44', id)
+        stubber.assert_no_pending_responses()
+
     def test_health_check_provider_options(self):
         provider, stubber = self._get_stubbed_provider()
         record = Record.new(


### PR DESCRIPTION
## Fix: Sanitize invalid characters in health check tag names                                                                                                                                          

Route53 health check tags can only contain letters, numbers, spaces, and these special characters: `_ . : / = + - @`.

Wildcard DNS records (e.g., `*.api.example.com`) contain asterisks which are not allowed in Route53 tags. This causes `InvalidInput` API errors when creating health checks for dynamic wildcard records:

```
botocore.errorfactory.InvalidInput: An error occurred (InvalidInput) when calling the ChangeTagsForResource operation: Invalid parameter : Tags can only contain letters, numbers, spaces, and the following special characters: _ . : / = + - @
```

For example, configuring the following record with the `octodns-route53` provider fails on the apply phase with `octodns-sync`

```
# zones/example.com.yaml                                                                                                                                                                                                                                                                                                                                                
  '*.api':  # Wildcard record name → FQDN *.api.example.com → tag contains *                                                                                                                                                                                                                                                                                              
    ttl: 60                                                                                                                                                                                                                                                                                                                                                               
    type: A                                                                                                                                                                                                                                                                                                                                                               
    values:                                                                                                                                                                                                                                                                                                                                                               
    - 52.1.1.1                                                                                                                                                                                                                                                                                                                                                            
    - 18.2.2.2                                                                                                                                                                                                                                                                                                                                                            
    dynamic:                                                                                                                                                                                                                                                                                                                                                              
      pools:                                                                                                                                                                                                                                                                                                                                                              
        na-pool:                                                                                                                                                                                                                                                                                                                                                          
          values:                                       
          - value: 52.1.1.1                                                                                                                                                                                                                                                                                                                                               
        eu-pool:                                                                                                                                                                                                                                                                                                                                                          
          values:                                                                                                                                                                                                                                                                                                                                                         
          - value: 18.2.2.2                                                                                                                                                                                                                                                                                                                                               
      rules:                                                                                                                                                                                                                                                                                                                                                              
      - geos: ['NA']                                                                                                                                                                                                                                                                                                                                                      
        pool: na-pool                                                                                                                                                                                                                                                                                                                                                     
      - geos: ['EU']                                                                                                                                                                                                                                                                                                                                                      
        pool: eu-pool                                                                                                                                                                                                                                                                                                                                                     
    octodns:                                                                                                                                                                                                                                                                                                                                                              
      healthcheck:                                                                                                                                                                                                                                                                                                                                                        
        host: *.api.example.com                                                                                                                                                                                                                                                                                                                                             
        path: /_health                                                                                                                                                                                                                                                                                                                                                    
        port: 443                                       
        protocol: HTTPS
```

## Implemented fix

Added `_sanitize_route53_tag_value()` function that replaces all invalid characters with hyphens, allowing health checks to be created for any DNS record name including wildcards.

### Changes

- Added `_sanitize_route53_tag_value()` sanitization function with Route53 API documentation link 
- Applied sanitization to health check Name tag creation
- Added `test_health_check_wildcard_record()` test case
- Maintains 100% test coverage