### PR TITLE
Version 1.2.0 bump & changelog update

### DIFF
--- a/.changelog/0c73fe57434541eea466526409284264.md
+++ b/.changelog/0c73fe57434541eea466526409284264.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/5a340cceedd84371a78f4c3fa59cdbb2.md
+++ b/.changelog/5a340cceedd84371a78f4c3fa59cdbb2.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Sanitize invalid characters in health check tag names to support wildcard DNS records

--- a/.changelog/5b081f490890489cbb3ab87a26127a60.md
+++ b/.changelog/5b081f490890489cbb3ab87a26127a60.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Ignore Value.validate deprecation warning

--- a/.changelog/b9de9ae1fd284fce8475a69793bee5b1.md
+++ b/.changelog/b9de9ae1fd284fce8475a69793bee5b1.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Quick pass at migrating to Validators, backwards compat

--- a/.changelog/bead6213e4a247e2a1cbfbdac0e5e187.md
+++ b/.changelog/bead6213e4a247e2a1cbfbdac0e5e187.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Remove stale filterwarnings from pyproject.toml pytest section

--- a/.changelog/c51b17045a454827aaa8873e8dbaf655.md
+++ b/.changelog/c51b17045a454827aaa8873e8dbaf655.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0 - 2026-06-29
+
+Minor:
+* Quick pass at migrating to Validators, backwards compat - [#133](https://github.com/octodns/octodns-route53/pull/133)
+
+Patch:
+* Sanitize invalid characters in health check tag names to support wildcard DNS records - [#136](https://github.com/octodns/octodns-route53/pull/136)
+
 ## 1.1.0 - 2026-04-03
 
 Minor:

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -7,7 +7,7 @@ from .record import Route53AliasRecord
 from .source import Ec2Source, ElbSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.1.0'
+__version__ = __VERSION__ = '1.2.0'
 
 # quell warnings
 Ec2Source


### PR DESCRIPTION
## 1.2.0 - 2026-06-29

Minor:
* Quick pass at migrating to Validators, backwards compat - [#133](https://github.com/octodns/octodns-route53/pull/133)

Patch:
* Sanitize invalid characters in health check tag names to support wildcard DNS records - [#136](https://github.com/octodns/octodns-route53/pull/136)

