### PR TITLE
Fix wildcard and long fqdn handling in Route53Provider._gc_health_checks

### DIFF
--- a/.changelog/3abb8c3e2c224941aed8bfb7fb4648b2.md
+++ b/.changelog/3abb8c3e2c224941aed8bfb7fb4648b2.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Fix wildcard and long fqdn handling in Route53Provider._gc_health_checks

--- a/octodns_route53/provider.py
+++ b/octodns_route53/provider.py
@@ -1870,7 +1870,17 @@ class Route53Provider(_AuthMixin, BaseProvider):
         # Now we need to run through ALL the health checks looking for those
         # that apply to this record, deleting any that do and are no longer in
         # use
-        expected_re = re.compile(fr'^\d\d\d\d:{record._type}:{record.fqdn}:')
+        # Build the expected CallerReference prefix the same way we do when
+        # creating/finding health checks (see _healthcheck_ref_prefix); this
+        # handles both wildcard fqdns (the `*` must be treated as a literal,
+        # not a regex quantifier) and long fqdns (which get hashed rather than
+        # embedded directly). We drop the leading version and match \d\d\d\d
+        # instead so GC still spans all versions.
+        prefix = _healthcheck_ref_prefix(
+            self.HEALTH_CHECK_VERSION, record._type, record.fqdn
+        )
+        ident = prefix.split(':', 1)[1]
+        expected_re = re.compile(fr'^\d\d\d\d:{re.escape(ident)}:')
         # UNITL 1.0: we'll clean out the previous version of Route53 health
         # checks as best as we can.
         expected_legacy_host = record.fqdn[:-1]

--- a/tests/test_octodns_provider_route53.py
+++ b/tests/test_octodns_provider_route53.py
@@ -3449,6 +3449,155 @@ class TestRoute53Provider(TestCase):
         provider._gc_health_checks(record, [])
         stubber.assert_no_pending_responses()
 
+    def test_health_check_gc_wildcard_vs_sibling(self):
+        # Regression test for #140: a wildcard record's fqdn contains a
+        # literal `*` which, prior to the fix, was interpolated straight
+        # into the gc regex and interpreted as a quantifier rather than a
+        # literal character. That meant the wildcard's own stale health
+        # checks were never matched (never gc'd, a permanent leak) while a
+        # same-name non-wildcard sibling's in-use health checks *were*
+        # matched and deleted (breaking its failover).
+        provider, stubber = self._get_stubbed_provider()
+
+        wildcard_fqdn = '*.foo.unit.tests.'
+        sibling_fqdn = 'foo.unit.tests.'
+
+        wild_prefix = _healthcheck_ref_prefix(
+            Route53Provider.HEALTH_CHECK_VERSION, 'A', wildcard_fqdn
+        )
+        sibling_prefix = _healthcheck_ref_prefix(
+            Route53Provider.HEALTH_CHECK_VERSION, 'A', sibling_fqdn
+        )
+
+        health_check_config = {
+            'Disabled': False,
+            'EnableSNI': True,
+            'Inverted': False,
+            'Type': 'HTTPS',
+            'FullyQualifiedDomainName': 'unit.tests',
+            'IPAddress': '4.2.3.4',
+            'ResourcePath': '/_dns',
+            'Port': 443,
+            'MeasureLatency': True,
+            'RequestInterval': 10,
+            'FailureThreshold': 6,
+        }
+        health_checks = [
+            {
+                'Id': 'wild-stale-id',
+                'CallerReference': f'{wild_prefix}:wild-stale',
+                'HealthCheckConfig': health_check_config,
+                'HealthCheckVersion': 2,
+            },
+            {
+                'Id': 'wild-in-use-id',
+                'CallerReference': f'{wild_prefix}:wild-in-use',
+                'HealthCheckConfig': health_check_config,
+                'HealthCheckVersion': 2,
+            },
+            {
+                'Id': 'sibling-in-use-id',
+                'CallerReference': f'{sibling_prefix}:sibling-in-use',
+                'HealthCheckConfig': health_check_config,
+                'HealthCheckVersion': 2,
+            },
+        ]
+        stubber.add_response(
+            'list_health_checks',
+            {
+                'HealthChecks': health_checks,
+                'IsTruncated': False,
+                'MaxItems': '100',
+                'Marker': '',
+            },
+        )
+
+        wildcard_record = Record.new(
+            self.expected, '*.foo', {'ttl': 61, 'type': 'A', 'value': '2.2.3.4'}
+        )
+
+        # only the wildcard's own stale health check should be deleted, its
+        # in-use one and the sibling's in-use one must be left alone
+        stubber.add_response(
+            'delete_health_check', {}, {'HealthCheckId': 'wild-stale-id'}
+        )
+        provider._gc_health_checks(
+            wildcard_record, [DummyR53Record('wild-in-use-id')]
+        )
+        stubber.assert_no_pending_responses()
+
+        # gc'ing the sibling only ever touches its own health checks
+        sibling_record = Record.new(
+            self.expected, 'foo', {'ttl': 61, 'type': 'A', 'value': '2.2.3.4'}
+        )
+        provider._gc_health_checks(
+            sibling_record, [DummyR53Record('sibling-in-use-id')]
+        )
+        stubber.assert_no_pending_responses()
+
+    def test_health_check_gc_long_fqdn(self):
+        # Regression test for the hashing-related gc gap found while fixing
+        # #140: for long fqdns _healthcheck_ref_prefix hashes the fqdn
+        # rather than embedding it directly, so gc has to build its
+        # matching prefix the same way rather than matching on the raw
+        # fqdn, or it'll never find (and thus never clean up) those health
+        # checks.
+        provider, stubber = self._get_stubbed_provider()
+
+        long_fqdn = (
+            'this-is-a-very-longggggggg-record-for-testing-purposes.'
+            'unit.tests.'
+        )
+        prefix = _healthcheck_ref_prefix(
+            Route53Provider.HEALTH_CHECK_VERSION, 'A', long_fqdn
+        )
+        # the prefix should have been hashed, not the raw fqdn
+        self.assertNotIn(long_fqdn, prefix)
+
+        health_check_config = {
+            'Disabled': False,
+            'EnableSNI': True,
+            'Inverted': False,
+            'Type': 'HTTPS',
+            'FullyQualifiedDomainName': 'unit.tests',
+            'IPAddress': '4.2.3.4',
+            'ResourcePath': '/_dns',
+            'Port': 443,
+            'MeasureLatency': True,
+            'RequestInterval': 10,
+            'FailureThreshold': 6,
+        }
+        health_checks = [
+            {
+                'Id': 'long-stale-id',
+                'CallerReference': f'{prefix}:long-stale',
+                'HealthCheckConfig': health_check_config,
+                'HealthCheckVersion': 2,
+            }
+        ]
+        stubber.add_response(
+            'list_health_checks',
+            {
+                'HealthChecks': health_checks,
+                'IsTruncated': False,
+                'MaxItems': '100',
+                'Marker': '',
+            },
+        )
+
+        record = Record.new(
+            self.expected,
+            'this-is-a-very-longggggggg-record-for-testing-purposes',
+            {'ttl': 61, 'type': 'A', 'value': '2.2.3.4'},
+        )
+        self.assertEqual(long_fqdn, record.fqdn)
+
+        stubber.add_response(
+            'delete_health_check', {}, {'HealthCheckId': 'long-stale-id'}
+        )
+        provider._gc_health_checks(record, [])
+        stubber.assert_no_pending_responses()
+
     def test_legacy_health_check_gc(self):
         provider, stubber = self._get_stubbed_provider()
 


### PR DESCRIPTION
## Summary

`Route53Provider._gc_health_checks` built its matching regex by interpolating `record.fqdn` directly into a pattern:

```python
expected_re = re.compile(fr'^\d\d\d\d:{record._type}:{record.fqdn}:')
```

This had two problems, both fixed here by building the match prefix the same way health checks are created/found (via `_healthcheck_ref_prefix`) and escaping it before compiling the regex.

### Original issue: unescaped wildcard fqdn (#140)

For a wildcard record (e.g. `*.foo.example.com.`), the leading `*` was interpreted as a regex quantifier instead of a literal character. This meant:
- The wildcard record's **own** stale health checks were never matched, so they were never garbage collected — a permanent resource leak.
- The pattern **did** accidentally match a same-name non-wildcard sibling's (`foo.example.com.`) CallerReferences (`:*.` degrades to "zero-or-more colons, then any one character," which happens to line up), so GC for the wildcard record deleted the sibling's in-use health checks, leaving its RRSets pointing at deleted `HealthCheckId`s and silently breaking its health-checked failover.

### Related issue found while fixing this

`_healthcheck_ref_prefix` (used when creating/finding health checks) hashes the fqdn instead of embedding it directly whenever the resulting CallerReference prefix would exceed 64 characters. `_gc_health_checks`, however, always matched against the raw fqdn, so it could never match a hashed CallerReference. Any record with a long enough fqdn to trigger hashing would have its health checks leak in the same way as the wildcard case, independent of the wildcard bug.

## Fix

`_gc_health_checks` now derives its expected prefix from `_healthcheck_ref_prefix()` (the same helper used elsewhere to build/find CallerReferences) and `re.escape()`s it before compiling the regex, so it's wildcard-safe, long-fqdn-safe, and stays consistent with how CallerReferences are actually generated.

## Test plan

- [x] New test `test_health_check_gc_wildcard_vs_sibling`: verifies gc'ing a wildcard record deletes only its own stale health check, not a same-name sibling's in-use one (and vice versa). Confirmed this test fails against the pre-fix code with the exact failure mode described in #140 (deletes the sibling's in-use check instead of the wildcard's stale one).
- [x] New test `test_health_check_gc_long_fqdn`: verifies gc'ing a record with a long fqdn correctly matches and cleans up its hashed CallerReference. Confirmed this test fails against the pre-fix code.
- [x] `./script/test`, `./script/lint`, `./script/format`, `./script/coverage` all pass (100% coverage maintained).

/cc Fixes #140