### PR TITLE
Version 1.3.0 bump & changelog update

### DIFF
--- a/.changelog/3abb8c3e2c224941aed8bfb7fb4648b2.md
+++ b/.changelog/3abb8c3e2c224941aed8bfb7fb4648b2.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Fix wildcard and long fqdn handling in Route53Provider._gc_health_checks

--- a/.changelog/f6ccf688b6da46f18fcc912e89697334.md
+++ b/.changelog/f6ccf688b6da46f18fcc912e89697334.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Modernize packaging: move build metadata from setup.py into pyproject.toml, remove setup.py; require Python >=3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.0 - 2026-07-22
+
+Minor:
+* Modernize packaging: move build metadata from setup.py into pyproject.toml, remove setup.py; require Python >=3.10 - [#139](https://github.com/octodns/octodns-route53/pull/139)
+
+Patch:
+* Fix wildcard and long fqdn handling in Route53Provider._gc_health_checks - [#141](https://github.com/octodns/octodns-route53/pull/141)
+
 ## 1.2.0 - 2026-06-29
 
 Minor:

--- a/octodns_route53/__init__.py
+++ b/octodns_route53/__init__.py
@@ -7,7 +7,7 @@ from .record import Route53AliasRecord
 from .source import Ec2Source, ElbSource
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.2.0'
+__version__ = __VERSION__ = '1.3.0'
 
 # quell warnings
 Ec2Source


### PR DESCRIPTION
## 1.3.0 - 2026-07-22

Minor:
* Modernize packaging: move build metadata from setup.py into pyproject.toml, remove setup.py; require Python >=3.10 - [#139](https://github.com/octodns/octodns-route53/pull/139)

Patch:
* Fix wildcard and long fqdn handling in Route53Provider._gc_health_checks - [#141](https://github.com/octodns/octodns-route53/pull/141)

